### PR TITLE
Convert all tests to pytest

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -27,7 +27,7 @@ This will be run automatically when you attempt to commit code but if you want t
 
     poetry run pre-commit run --all-files
 
-This project uses the `pytest <https://docs.pytest.org/>` framework with `pytest-django <https://pytest-django.readthedocs.io/en/latest/>` enabling Django tests and `pytest-playwright <https://playwright.dev/python/docs/test-runners>` for end-to-end testing. This replaces the default Django tests using `unittest`.
+This project uses the `pytest <https://docs.pytest.org/>` framework with `pytest-django <https://pytest-django.readthedocs.io/en/latest/>`_ enabling Django tests and `pytest-playwright <https://playwright.dev/python/docs/test-runners>`_ for end-to-end testing. This replaces the default Django tests using unittest.
 
 Django tests can be run by running:
 
@@ -35,4 +35,4 @@ Django tests can be run by running:
 
     pytest
 
-While `pytest` is backwards-compatible with `unittest`, there are some key differences that implementers need to understand. If you're new to pytest in Django or playwright testing, reviewing the documentation for these libraries is well worth the time.
+While pytest is backwards-compatible with unittest, there are some key differences that implementers need to understand. If you're new to pytest in Django or playwright testing, reviewing the documentation for these libraries is well worth the time.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -27,9 +27,12 @@ This will be run automatically when you attempt to commit code but if you want t
 
     poetry run pre-commit run --all-files
 
+This project uses the `pytest <https://docs.pytest.org/>` framework with `pytest-django <https://pytest-django.readthedocs.io/en/latest/>` enabling Django tests and `pytest-playwright <https://playwright.dev/python/docs/test-runners>` for end-to-end testing. This replaces the default Django tests using `unittest`.
+
 Django tests can be run by running:
 
 .. code-block:: console
-    
-    ./manage.py test
-    
+
+    pytest
+
+While `pytest` is backwards-compatible with `unittest`, there are some key differences that implementers need to understand. If you're new to pytest in Django or playwright testing, reviewing the documentation for these libraries is well worth the time.

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -27,7 +27,7 @@ This will be run automatically when you attempt to commit code but if you want t
 
     poetry run pre-commit run --all-files
 
-This project uses the `pytest <https://docs.pytest.org/>` framework with `pytest-django <https://pytest-django.readthedocs.io/en/latest/>`_ enabling Django tests and `pytest-playwright <https://playwright.dev/python/docs/test-runners>`_ for end-to-end testing. This replaces the default Django tests using unittest.
+This project uses the `pytest <https://docs.pytest.org/>`_ framework with `pytest-django <https://pytest-django.readthedocs.io/en/latest/>`_ enabling Django tests and `pytest-playwright <https://playwright.dev/python/docs/test-runners>`_ for end-to-end testing. This replaces the default Django tests using unittest.
 
 Django tests can be run by running:
 

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           pkg-manager: poetry
       - run: poetry run pre-commit run --all-files
       - run: poetry run playwright install
-      - run: poetry run coverage run --source='.' manage.py test
+      - run: poetry run coverage run --source='.' -m pytest
       - store_test_results:
           path: test_reports
       - run: poetry run coverage xml

--- a/{{cookiecutter.repo_name}}/poetry.lock
+++ b/{{cookiecutter.repo_name}}/poetry.lock
@@ -79,6 +79,20 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+
+[[package]]
 name = "autopep8"
 version = "1.7.0"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -655,6 +669,14 @@ python-versions = "*"
 setuptools = ">=0.6b1"
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "ipdb"
 version = "0.13.9"
 description = "IPython-enabled pdb"
@@ -885,6 +907,18 @@ greenlet = "1.1.3"
 pyee = "8.1.0"
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "poetryup"
 version = "0.5.6"
 description = "Update dependencies and bump their version in the pyproject.toml file"
@@ -974,6 +1008,14 @@ urwid = ">=1.1.1"
 urwid_readline = "*"
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -1038,6 +1080,67 @@ python-versions = ">=3.6.8"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pytest"
+version = "7.1.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-base-url"
+version = "2.0.0"
+description = "pytest plugin for URL based testing"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+pytest = ">=3.0.0,<8.0.0"
+requests = ">=2.9"
+
+[[package]]
+name = "pytest-django"
+version = "4.5.2"
+description = "A Django plugin for pytest."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.3.0"
+description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+playwright = ">=1.18"
+pytest = "*"
+pytest-base-url = "*"
+python-slugify = "*"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1047,6 +1150,20 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-slugify"
+version = "6.1.2"
+description = "A Python slugify application that also handles Unicode"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "python3-openid"
@@ -1242,6 +1359,14 @@ description = "Traceback serialization library."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "toml"
@@ -1445,7 +1570,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "971b61d7085640ec2343e35a3b591c59690cad3f17a98b78b74f8f3eee227167"
+content-hash = "a03c7bb4b67693e4a0a5bdcc30be94a9a42bce274f2d646e9797fd218fabb549"
 
 [metadata.files]
 appdirs = [
@@ -1494,6 +1619,10 @@ asttokens = [
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
     {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+]
+attrs = [
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 autopep8 = [
     {file = "autopep8-1.7.0-py2.py3-none-any.whl", hash = "sha256:6f09e90a2be784317e84dc1add17ebfc7abe3924239957a37e5040e27d812087"},
@@ -1969,6 +2098,10 @@ idna = [
 importmagic = [
     {file = "importmagic-0.1.7.tar.gz", hash = "sha256:3f7757a5b74c9a291e20e12023bb3bf71bc2fa3adfb15a08570648ab83eaf8d8"},
 ]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 ipdb = [
     {file = "ipdb-0.13.9.tar.gz", hash = "sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5"},
 ]
@@ -2207,6 +2340,10 @@ playwright = [
     {file = "playwright-1.27.0-py3-none-win32.whl", hash = "sha256:fe90b890061f729d2ea2f547fc5b316a5e6361e3659fbc639ee35e08be38d13f"},
     {file = "playwright-1.27.0-py3-none-win_amd64.whl", hash = "sha256:8cbeab451099cf0d52d9e80baf970363f900c8cc85ecf4d7dcde76a86c47880a"},
 ]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
 poetryup = [
     {file = "poetryup-0.5.6-py3-none-any.whl", hash = "sha256:1223a0970d6fbfa1e30ed116fa58d1557f853b0ba0ef5860cd52ce27f8c57af9"},
     {file = "poetryup-0.5.6.tar.gz", hash = "sha256:e3bcea00df86d10d8a48837ac79d34ea109e05b1952e7f4a3a15c2e45b9ec052"},
@@ -2291,6 +2428,10 @@ ptyprocess = [
 pudb = [
     {file = "pudb-2022.1.2.tar.gz", hash = "sha256:6b83ab805bddb53710109690a2237e98bf83c0b3a00033c517cdf5f6a8fa470d"},
 ]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
@@ -2315,9 +2456,29 @@ pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
+pytest = [
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+pytest-base-url = [
+    {file = "pytest-base-url-2.0.0.tar.gz", hash = "sha256:e1e88a4fd221941572ccdcf3bf6c051392d2f8b6cef3e0bc7da95abec4b5346e"},
+    {file = "pytest_base_url-2.0.0-py3-none-any.whl", hash = "sha256:ed36fd632c32af9f1c08f2c2835dcf42ca8fcd097d6ed44a09f253d365ad8297"},
+]
+pytest-django = [
+    {file = "pytest-django-4.5.2.tar.gz", hash = "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"},
+    {file = "pytest_django-4.5.2-py3-none-any.whl", hash = "sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e"},
+]
+pytest-playwright = [
+    {file = "pytest-playwright-0.3.0.tar.gz", hash = "sha256:62b843b73d259431380393b335bee65cc7a420c9095c83f78274b6b508cb2f33"},
+    {file = "pytest_playwright-0.3.0-py3-none-any.whl", hash = "sha256:2f41058f4a769a2c9631baacec65e9ebb3255e34519f0aab7f46e4c7fe66d127"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-slugify = [
+    {file = "python-slugify-6.1.2.tar.gz", hash = "sha256:272d106cb31ab99b3496ba085e3fea0e9e76dcde967b5e9992500d1f785ce4e1"},
+    {file = "python_slugify-6.1.2-py2.py3-none-any.whl", hash = "sha256:7b2c274c308b62f4269a9ba701aa69a797e9bca41aeee5b3a9e79e36b6656927"},
 ]
 python3-openid = [
     {file = "python3-openid-3.2.0.tar.gz", hash = "sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf"},
@@ -2338,6 +2499,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -2407,6 +2575,10 @@ sqlparse = [
 tblib = [
     {file = "tblib-1.7.0-py2.py3-none-any.whl", hash = "sha256:289fa7359e580950e7d9743eab36b0691f0310fce64dee7d9c31065b8f723e23"},
     {file = "tblib-1.7.0.tar.gz", hash = "sha256:059bd77306ea7b419d4f76016aef6d7027cc8a0785579b5aad198803435f882c"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -2,7 +2,7 @@
 name = "{{cookiecutter.repo_name}}"
 version = "0.1.0"
 description = ""
-authors = ["Ben Beecher <ben@lightmatter.com>"]
+authors = ["{{cookiecutter.author_name}} <{{cookiecutter.email}}>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -32,7 +32,7 @@ django-jinja = "^2.10.2"
 heroicons = {extras = ["jinja"], version = "^1.8.0"}
 django-rich = "^1.4.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 Werkzeug = "2.0.2"
 coverage = {extras = ["toml"], version = "^6.4.1"}
 ipython = "^7.31.1"
@@ -43,7 +43,6 @@ model-bakery = "^1.4.0"
 watchdog = "2.1.6"
 honcho = "1.1.0"
 unittest-xml-reporting = "^3.2.0"
-playwright = "^1.18.2"
 pywatchman = "^1.4.1"
 icecream = "^2.1.1"
 pre-commit = "^2.17.0"
@@ -52,6 +51,10 @@ poetryup = "^0.5.1"
 importmagic = "^0.1.7"
 epc = "^0.0.5"
 django-silk = "^5.0.1"
+
+[tool.poetry.group.test.dependencies]
+pytest-django = "^4.5.2"
+pytest-playwright = "^0.3.0"
 
 [tool.black]
 force-exclude = '''
@@ -69,27 +72,27 @@ branch = true
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
 exclude_lines = [
-    # Have to re-enable the standard pragma
-    "pragma: no cover",
+  # Have to re-enable the standard pragma
+  "pragma: no cover", # Have to re-enable the standard pragma
 
-    # Don't complain about missing debug-only code:
-    "def __repr__",
-    "if self.debug",
+  # Don't complain about missing debug-only code:
+  "def __repr__",
+  "if self.debug",
 
-    # Don't complain if tests don't hit defensive assertion code:
-    "raise AssertionError",
-    "raise NotImplementedError",
+  # Don't complain if tests don't hit defensive assertion code:
+  "raise AssertionError",
+  "raise NotImplementedError",
 
-    # Don't complain if non-runnable code isn't run:
-    "if 0:",
-    "if __name__ == .__main__.:",
+  # Don't complain if non-runnable code isn't run:
+  "if 0:",
+  "if __name__ == .__main__.:",
 ]
 
 ignore_errors = true
-omit = ["*/migrations/*","manage.py","{{cookiecutter.repo_name}}/config/*"]
+omit = ["*/migrations/*", "manage.py", "{{cookiecutter.repo_name}}/config/*"]
 
 [tool.isort]
-line_length = "92"
+line_length = 92
 profile = "black"
 skip_glob = "*migrations/*.py"
 known_third_party = "django,django.contrib,django.utils"
@@ -122,16 +125,41 @@ pyflakes = ["+*", "-E5110"]
 pylint = ["-*"]
 
 
-[tool.pylint]
-    [tool.pylint.master]
-    load-plugins="pylint_django, pylint_celery"
-    ignore-paths = [ "^.*/migrations/.*$",]
+[tool.pylint.main]
+load-plugins = ["pylint_django", "pylint_celery"]
+ignore-paths = [".*\\\\migrations\\\\.*|.*/migrations/.*"]
 
-    [tool.pylint.messages_control]
-    disable = "C0330, C0326, C0115, C0116, C0114, C0103, C0415, W0707, W0511, R0903, R0201, R0913, W0212, W0221"
+[tool.pylint.messages_control]
+disable = [
+  "C0115",
+  "C0116",
+  "C0114",
+  "C0103",
+  "C0415",
+  "W0707",
+  "W0511",
+  "R0903",
+  "R0913",
+  "W0212",
+  "W0221",
+  "W1203",
+]
 
-    [tool.pylint.format]
-    max-line-length = "139"
+[tool.pylint.django_foreign_keys_referenced_by_strings]
+django-settings-module = "{{cookiecutter.repo_name}}.config.settings.local"
+
+[tool.pylint.format]
+max-line-length = 139
+
+[tool.djlint]
+ignore = ["H006", "H023", "T002"]
+profile = "django"
+indent = 2
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "{{cookiecutter.repo_name}}.config.settings.test"
+python_files = ["tests.py", "test_*.py", "*_tests.py"]
+addopts = ["--reuse-db"]
 
 
 [build-system]

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -73,7 +73,7 @@ branch = true
 # Regexes for lines to exclude from consideration
 exclude_lines = [
   # Have to re-enable the standard pragma
-  "pragma: no cover", # Have to re-enable the standard pragma
+  "pragma: no cover",
 
   # Don't complain about missing debug-only code:
   "def __repr__",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/conftest.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/conftest.py
@@ -6,7 +6,11 @@ from playwright.sync_api import Playwright
 
 
 @pytest.fixture(scope="session")
-def playwright(playwright: Playwright):
+def playwright(playwright: Playwright) -> Playwright:
+    """Override of playwright fixture so we can set up for use with Django.
+
+    Background: https://github.com/microsoft/playwright-python/issues/439
+    """
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
     return playwright

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/conftest.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/conftest.py
@@ -1,0 +1,12 @@
+# pylint: disable=redefined-outer-name
+import os
+
+import pytest
+from playwright.sync_api import Playwright
+
+
+@pytest.fixture(scope="session")
+def playwright(playwright: Playwright):
+    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+    return playwright

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/tests.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/tests.py
@@ -1,13 +1,17 @@
-from django.test import TestCase
+from http import HTTPStatus
+
+import pytest
 from django.urls import reverse
 
 
-class SimpleTest(TestCase):
-    def test_home(self):
-        url = reverse("home")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+@pytest.mark.django_db
+def test_home(client):
+    response = client.get(reverse("home"))
 
-    def test_error_route(self):
-        visit = lambda: self.client.get(reverse("error"))  # noqa:E731
-        self.assertRaises(Exception, visit)
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_error_route(client):
+    with pytest.raises(Exception):
+        client.get(reverse("error"))

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
@@ -25,7 +25,7 @@ def password():
 @pytest.fixture
 def super_user(password) -> User:
     return baker.make_recipe(
-        "sampleapp.user.user",
+        "{{cookiecutter.repo_name}}.user.user",
         is_superuser=True,
         is_staff=True,
         password=make_password(password),

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
@@ -1,310 +1,328 @@
+# pylint: disable=redefined-outer-name
+import uuid
 from http import HTTPStatus
 
+import pytest
 from django.contrib.auth.hashers import make_password
-from django.test import TestCase
 from django.urls import reverse
 from model_bakery import baker
-
-from {{cookiecutter.repo_name}}.util.tests import PlaywrightTestCase
+from playwright.sync_api import Page, expect
+from pytest_django.asserts import assertRedirects
 
 from .models import User
 
 
-class UserManagerTest(TestCase):
-    def test_create_user(self):
-        user = User.objects.create_user(  # noqa: S106
-            "jonnyrico@fednet.gov", password="iwanttoknowmore"
-        )  # nosec
-        User.objects.get(id=user.id)
+@pytest.fixture
+def password():
+    return uuid.uuid4().hex
 
 
-class LoginTest(PlaywrightTestCase):
-    def setUp(self):
-        super().setUp()
-        self.password = "IwouldLikeToKnowMore"  # noqa: S105
-        self.user = baker.make_recipe(
-            "{{cookiecutter.repo_name}}.user.user",
-            is_superuser=True,
-            is_staff=True,
-            password=make_password(self.password),
-        )
-        self.url = reverse("user:account_welcome")
-
-    def test_login(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.wait_for_selector("text=Log in/Sign up")
-        page.fill("[name=email]", self.user.email)
-        # TODO: Test for email is required attr
-        page.click("#welcome-button")
-        page.wait_for_selector(f"text=Welcome back, {self.user.first_name}!")
-        # TODO: Test for password is required attr
-        page.fill("[name=password]", self.password)
-        page.click("#login-button")
-        page.wait_for_load_state("networkidle")
-        actual = page.url.removeprefix(self.live_server_url)
-        self.assertEqual(actual, "/")
-
-    def test_login_email_case_insensitive(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.wait_for_selector("text=Log in/Sign up")
-        page.fill("[name=email]", self.user.email.upper())
-        page.click("#welcome-button")
-        page.wait_for_selector(f"text=Welcome back, {self.user.first_name}!")
-        page.fill("[name=password]", self.password)
-        page.click("#login-button")
-        page.wait_for_load_state("networkidle")
-        actual = page.url.removeprefix(self.live_server_url)
-        self.assertEqual(actual, "/")
-
-    def test_login_badpass(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.wait_for_selector("text=Log in/Sign up")
-        page.fill("[name=email]", self.user.email.upper())
-        page.click("#welcome-button")
-        page.fill("[name=password]", "BUGSRULE")
-        page.click("#login-button")
-        error = page.text_content(
-            "text=The e-mail address and/or password you specified are not correct."
-        )
-        self.assertTrue(error)
+@pytest.fixture
+def super_user(password):
+    return baker.make_recipe(
+        "sampleapp.user.user",
+        is_superuser=True,
+        is_staff=True,
+        password=make_password(password),
+    )
 
 
-class RegistrationLiveTest(PlaywrightTestCase):
-    def setUp(self):
-        super().setUp()
-        self.password = "yeahmanitsarealpass"  # noqa: S105
-        self.form_data = self.login_form_data = {
-            "email": "ben@coolguy.com",
-            "email2": "ben@coolguy.com",
-            "password1": self.password,
-            "password2": self.password,
-            "first_name": "ben",
-            "last_name": "beecher",
-        }
-        self.url = reverse("user:account_welcome")
-
-    def test_register(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.click('input[name="email"]')
-        page.fill('input[name="email"]', self.form_data["email"])
-        page.click("text=Continue")
-        page.click('[placeholder="E-mail\\ address\\ confirmation"]')
-        page.fill(
-            '[placeholder="E-mail\\ address\\ confirmation"]', self.form_data["email2"]
-        )
-        page.click('[placeholder="First\\ Name"]')
-        page.fill('[placeholder="First\\ Name"]', self.form_data["first_name"])
-        # Click [placeholder="Last\ Name"]
-        page.click('[placeholder="Last\\ Name"]')
-        # Fill [placeholder="Last\ Name"]
-        page.fill('[placeholder="Last\\ Name"]', self.form_data["last_name"])
-        # Click [placeholder="Password"]
-        page.click('[placeholder="Password"]')
-        # Fill [placeholder="Password"]
-        page.fill('[placeholder="Password"]', self.password)
-        # Click [placeholder="Password\ \(again\)"]
-        page.click('[placeholder="Password\\ \\(again\\)"]')
-        # Fill [placeholder="Password\ \(again\)"]
-        page.fill('[placeholder="Password\\ \\(again\\)"]', self.password)
-        with page.expect_navigation(wait_until="networkidle"):
-            page.click("text=Create Account")
-        actual = page.url.removeprefix(self.live_server_url)
-        self.assertEqual(actual, "/")
-
-    def test_register_email_no_match(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.click('input[name="email"]')
-        page.fill('input[name="email"]', self.form_data["email"])
-        page.click("text=Continue")
-        page.click('[placeholder="E-mail\\ address\\ confirmation"]')
-        page.fill('[placeholder="E-mail\\ address\\ confirmation"]', "email@bademail.com")
-        page.click('[placeholder="First\\ Name"]')
-        page.fill('[placeholder="First\\ Name"]', self.form_data["first_name"])
-        # Click [placeholder="Last\ Name"]
-        page.click('[placeholder="Last\\ Name"]')
-        # Fill [placeholder="Last\ Name"]
-        page.fill('[placeholder="Last\\ Name"]', self.form_data["last_name"])
-        # Click [placeholder="Password"]
-        page.click('[placeholder="Password"]')
-        # Fill [placeholder="Password"]
-        page.fill('[placeholder="Password"]', self.password)
-        # Click [placeholder="Password\ \(again\)"]
-        page.click('[placeholder="Password\\ \\(again\\)"]')
-        # Fill [placeholder="Password\ \(again\)"]
-        page.fill('[placeholder="Password\\ \\(again\\)"]', "somethingwronggarbage")
-
-        page.click("text=Create Account")
-
-        error = page.text_content("text=You must type the same email each time.")
-        self.assertTrue(error)
-
-    def test_register_pass_no_match(self):
-        page = self.context.new_page()
-        page.goto(f"{self.live_server_url}{self.url}")
-        page.click('input[name="email"]')
-        page.fill('input[name="email"]', self.form_data["email"])
-        page.click("text=Continue")
-        page.click('[placeholder="E-mail\\ address\\ confirmation"]')
-        page.fill(
-            '[placeholder="E-mail\\ address\\ confirmation"]', self.form_data["email2"]
-        )
-        page.click('[placeholder="First\\ Name"]')
-        page.fill('[placeholder="First\\ Name"]', self.form_data["first_name"])
-        # Click [placeholder="Last\ Name"]
-        page.click('[placeholder="Last\\ Name"]')
-        # Fill [placeholder="Last\ Name"]
-        page.fill('[placeholder="Last\\ Name"]', self.form_data["last_name"])
-        # Click [placeholder="Password"]
-        page.click('[placeholder="Password"]')
-        # Fill [placeholder="Password"]
-        page.fill('[placeholder="Password"]', self.password)
-        # Click [placeholder="Password\ \(again\)"]
-        page.click('[placeholder="Password\\ \\(again\\)"]')
-        # Fill [placeholder="Password\ \(again\)"]
-        page.fill('[placeholder="Password\\ \\(again\\)"]', "somethingwronggarbage")
-        page.click("text=Create Account")
-        error = page.text_content("text=You must type the same password each time.")
-        self.assertTrue(error)
+@pytest.fixture
+def form_data(password):
+    return {
+        "email": "ben@coolguy.com",
+        "email2": "ben@coolguy.com",
+        "password1": password,
+        "password2": password,
+        "first_name": "ben",
+        "last_name": "beecher",
+    }
 
 
-class RegistrationTest(TestCase):
-    def setUp(self):
-        self.password = "yeahmanitsarealpass"  # noqa: S105
-        self.form_data = self.login_form_data = {
-            "email": "ben@coolguy.com",
-            "email2": "ben@coolguy.com",
-            "password1": self.password,
-            "password2": self.password,
-            "first_name": "ben",
-            "last_name": "beecher",
-        }
-        self.url = reverse("account_signup")
-
-    def test_register(self):
-        actual = User.objects.count()
-        self.assertEqual(0, actual)
-        response = self.client.post(self.url, self.form_data, follow=True)
-        self.assertRedirects(response, "/")
-        actual = User.objects.count()
-        self.assertEqual(1, actual)
-        coolguy = User.objects.first()
-        self.assertTrue(coolguy.check_password(self.password))
-
-    def test_register_bad_repeat_email(self):
-        email = self.form_data["email"]
-        baker.make(User, email=email)
-
-        actual = User.objects.count()
-        self.assertEqual(1, actual)
-
-        response = self.client.post(self.url, self.form_data)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-
-        actual = User.objects.count()
-        self.assertEqual(1, actual)
-
-        self.form_data["email"] = email.upper()
-
-        response = self.client.post(self.url, self.form_data)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-
-        actual = User.objects.count()
-        self.assertEqual(1, actual)
-
-    def test_register_bad_repeat_pass1(self):
-        self.form_data["password1"] = "oh no, oh no"
-        response = self.client.post(self.url, self.form_data)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        actual = User.objects.count()
-        self.assertEqual(0, actual)
-
-    def test_register_bad_repeat_pass(self):
-        self.form_data["password2"] = "oh no, oh no"
-        response = self.client.post(self.url, self.form_data)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        actual = User.objects.count()
-        self.assertEqual(0, actual)
-
-    def test_register_no_repeat_pass(self):
-        del self.form_data["password2"]
-        response = self.client.post(self.url, self.form_data)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        actual = User.objects.count()
-        self.assertEqual(0, actual)
+@pytest.mark.django_db
+def test_create_user(password):
+    user = User.objects.create_user(  # noqa: S106
+        "jonnyrico@fednet.gov", password=password
+    )  # nosec
+    User.objects.get(id=user.id)
 
 
-class UserAdminTest(TestCase):
-    def setUp(self):
-        form_data = self.login_form_data = {
-            "username": "ben@coolguy.com",
-            "password": "yeahman",
-        }
-        self.user = baker.make_recipe(
-            "{{cookiecutter.repo_name}}.user.user",
-            email=form_data["username"],
-            is_superuser=True,
-            is_staff=True,
-            password=make_password(form_data["password"]),
-        )
+def test_login_live(page: Page, live_server, super_user, password):
+    header = page.locator('[slot="title"]')
 
-        self.client.login(
-            username=self.login_form_data["username"],
-            password=self.login_form_data["password"],
-        )
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
 
-    def test_user_admin_list(self):
-        url = reverse("admin:user_user_changelist")
-        response = self.client.get(url)
-        actual = response.status_code
-        expected = 200
-        self.assertEqual(actual, expected)
+    page.fill("input[name=email]", super_user.email)
+    page.click("#welcome-button")
+    expect(header).to_have_text(f"Welcome back, {super_user.first_name}!")
 
-    def test_user_admin_detail(self):
-        url = reverse("admin:user_user_change", args=[self.user.id])
-        response = self.client.get(url)
-        actual = response.status_code
-        expected = 200
-        self.assertEqual(actual, expected)
+    page.fill("input[name=password]", password)
+    page.click("#login-button")
+    expect(page).to_have_url(f"{live_server.url}/")
 
-    def test_user_admin_add(self):
-        url = reverse("admin:user_user_add")
 
-        form_data = {
-            "email": "robertcop@ocp.com",
+def test_login_no_email_live(page: Page, live_server):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.click("#welcome-button")
+    expect(page.locator("input[name=email]")).to_be_focused()
+
+
+def test_login_no_password_live(page: Page, live_server, super_user):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill("input[name=email]", super_user.email)
+    page.click("#welcome-button")
+    expect(header).to_have_text(f"Welcome back, {super_user.first_name}!")
+
+    page.click("#login-button")
+    expect(page.locator("input[name=password]")).to_be_focused()
+
+
+def test_login_email_case_insensitive_live(page: Page, live_server, super_user, password):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill("input[name=email]", super_user.email.upper())
+    page.click("#welcome-button")
+    expect(header).to_have_text(f"Welcome back, {super_user.first_name}!")
+
+    page.fill("input[name=password]", password)
+    page.click("#login-button")
+    expect(page).to_have_url(f"{live_server.url}/")
+
+
+def test_login_badpass_live(page: Page, live_server, super_user):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill("input[name=email]", super_user.email.upper())
+    page.click("#welcome-button")
+    expect(header).to_have_text(f"Welcome back, {super_user.first_name}!")
+
+    page.fill("input[name=password]", "BUGSRULE")
+    page.click("#login-button")
+
+    expect(page.locator(".errorlist")).to_contain_text(
+        "The e-mail address and/or password you specified are not correct."
+    )
+
+
+@pytest.mark.django_db
+def test_register(client, form_data):
+    user_password = form_data["password1"]
+
+    assert User.objects.count() == 0
+
+    response = client.post(reverse("account_signup"), form_data, follow=True)
+    assertRedirects(response, "/")
+
+    assert User.objects.count() == 1
+
+    user = User.objects.first()
+    assert user.check_password(user_password)
+
+
+@pytest.mark.django_db
+def test_register_bad_repeat_email(client, form_data):
+    email = form_data["email"]
+    baker.make(User, email=email)
+    url = reverse("account_signup")
+
+    assert User.objects.count() == 1
+
+    response = client.post(url, form_data)
+    assert response.status_code == HTTPStatus.OK
+    assert User.objects.count() == 1
+
+    form_data["email"] = email.upper()
+    response = client.post(url, form_data)
+    assert response.status_code == HTTPStatus.OK
+    assert User.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_register_bad_repeat_pass1(client, form_data):
+    form_data["password1"] = "oh no, oh no"
+
+    response = client.post(reverse("account_signup"), form_data)
+    assert response.status_code == HTTPStatus.OK
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_register_bad_repeat_pass2(client, form_data):
+    form_data["password2"] = "oh no, oh no"
+
+    response = client.post(reverse("account_signup"), form_data)
+    assert response.status_code == HTTPStatus.OK
+    assert User.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_register_no_repeat_pass(client, form_data):
+    del form_data["password2"]
+
+    response = client.post(reverse("account_signup"), form_data)
+    assert response.status_code == HTTPStatus.OK
+    assert User.objects.count() == 0
+
+
+def test_register_live(page: Page, live_server, form_data):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill('input[name="email"]', form_data["email"])
+    page.click("#welcome-button")
+    expect(header).to_have_text("Sign up")
+
+    page.fill('input[placeholder="E-mail address confirmation"]', form_data["email2"])
+    page.fill('input[placeholder="First Name"]', form_data["first_name"])
+    page.fill('input[placeholder="Last Name"]', form_data["last_name"])
+    page.fill('input[placeholder="Password"]', form_data["password1"])
+    page.fill('input[placeholder="Password (again)"]', form_data["password2"])
+    page.click("text=Create Account")
+
+    expect(page).to_have_url(f"{live_server.url}/")
+
+
+def test_register_bad_repeat_email_live(page: Page, live_server, form_data):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill('input[name="email"]', form_data["email"])
+    page.click("#welcome-button")
+    expect(header).to_have_text("Sign up")
+
+    page.fill('input[placeholder="E-mail address confirmation"]', "email@bademail.com")
+    page.fill('input[placeholder="First Name"]', form_data["first_name"])
+    page.fill('input[placeholder="Last Name"]', form_data["last_name"])
+    page.fill('input[placeholder="Password"]', form_data["password1"])
+    page.fill('input[placeholder="Password (again)"]', form_data["password2"])
+    page.click("text=Create Account")
+
+    expect(page.locator(".errorlist")).to_contain_text(
+        "You must type the same email each time."
+    )
+
+
+def test_register_bad_repeat_pass1_live(page: Page, live_server, form_data):
+    header = page.locator('[slot="title"]')
+
+    page.goto(f'{live_server.url}{reverse("user:account_welcome")}')
+    expect(header).to_have_text("Log in/Sign up")
+
+    page.fill('input[name="email"]', form_data["email"])
+    page.click("#welcome-button")
+    expect(header).to_have_text("Sign up")
+
+    page.fill('input[placeholder="E-mail address confirmation"]', form_data["email2"])
+    page.fill('input[placeholder="First Name"]', form_data["first_name"])
+    page.fill('input[placeholder="Last Name"]', form_data["last_name"])
+    page.fill('input[placeholder="Password"]', form_data["password1"])
+    page.fill('input[placeholder="Password (again)"]', "somethingwronggarbage")
+    page.click("text=Create Account")
+
+    expect(page.locator(".errorlist")).to_contain_text(
+        "You must type the same password each time."
+    )
+
+
+@pytest.mark.django_db
+def test_user_admin_list(client, super_user, password):
+    client.login(
+        username=super_user.email,
+        password=password,
+    )
+
+    response = client.get(reverse("admin:user_user_changelist"))
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_user_admin_detail(client, super_user, password):
+    client.login(
+        username=super_user.email,
+        password=password,
+    )
+
+    response = client.get(reverse("admin:user_user_change", args=[super_user.id]))
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.django_db
+def test_user_admin_add(client, super_user, password):
+    client.login(
+        username=super_user.email,
+        password=password,
+    )
+
+    email = "robertcop@ocp.com"
+    actual = client.post(
+        reverse("admin:user_user_add"),
+        {
+            "email": email,
             "password1": "deadoraliveyourecomingwithme",
             "password2": "deadoraliveyourecomingwithme",
-        }
-        actual = self.client.post(url, form_data)
-        new_user = User.objects.latest("created")
-        self.assertEqual(new_user.email, "robertcop@ocp.com")
+        },
+    )
 
-        expected = reverse("admin:user_user_change", args=[new_user.id])
-        self.assertRedirects(actual, expected)
+    new_user = User.objects.latest("created")
+    assert new_user.email == email
 
-    def test_user_admin_add_different_passwords(self):
-        url = reverse("admin:user_user_add")
-        form_data = {
+    expected = reverse("admin:user_user_change", args=[new_user.id])
+    assertRedirects(actual, expected)
+
+
+@pytest.mark.django_db
+def test_user_admin_add_different_passwords(client, super_user, password):
+    client.login(
+        username=super_user.email,
+        password=password,
+    )
+
+    response = client.post(
+        reverse("admin:user_user_add"),
+        {
             "email": "robertcop@ocp.com",
             "password1": "deadoraliveyourecomingwithme",
             "password2": "freezecreep",
-        }
-        response = self.client.post(url, form_data)
-        actual = response.context["adminform"].form.errors
-        expected = {"password2": ["The two password fields didn’t match."]}
-        self.assertEqual(actual, expected)
+        },
+    )
 
-    def test_user_admin_change(self):
-        url = reverse("admin:user_user_change", args=[self.user.id])
-        form_data = {
+    expected = {"password2": ["The two password fields didn’t match."]}
+    assert response.context["adminform"].form.errors == expected
+
+
+@pytest.mark.django_db
+def test_user_admin_change(client, super_user, password):
+    client.login(
+        username=super_user.email,
+        password=password,
+    )
+
+    actual = client.post(
+        reverse("admin:user_user_change", args=[super_user.id]),
+        {
             "email": "ben@coolguy.com",
             "last_login_0": "2015-05-20",
             "last_login_1": "03:38:28",
-        }
-        actual = self.client.post(url, form_data)
-        expected = reverse("admin:user_user_changelist")
-        self.assertRedirects(actual, expected, target_status_code=302)
+        },
+    )
+    expected = reverse("admin:user_user_changelist")
+    assertRedirects(actual, expected, target_status_code=HTTPStatus.FOUND)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/user/tests.py
@@ -14,11 +14,16 @@ from .models import User
 
 @pytest.fixture
 def password():
+    """Generate a unique password string.
+
+    Can be referenced by tests also. For instance, we create a super user, then log in that
+    super user using the data from this password fixture.
+    """
     return uuid.uuid4().hex
 
 
 @pytest.fixture
-def super_user(password):
+def super_user(password) -> User:
     return baker.make_recipe(
         "sampleapp.user.user",
         is_superuser=True,
@@ -28,7 +33,7 @@ def super_user(password):
 
 
 @pytest.fixture
-def form_data(password):
+def form_data(password) -> dict:
     return {
         "email": "ben@coolguy.com",
         "email2": "ben@coolguy.com",


### PR DESCRIPTION
Converts all current test logic to work with pytest.

**Note:** #171 must be refactored to run pytest.

- Adds `pytest`, `pytest-django`, and `pytest-playwright`
- Refactors all existing Django `unittest` classes to `pytest` functions
- Lots of test simplification/cleanup/streamlining
- All TODO tests now implemented
  - Adds `test_send_email`
  - Adds `test_login_no_email_live`
  - Adds `test_login_no_password_live`
- All Playwright tests now assert changes with `expect` rather than `wait_for_*` [as docs suggest](https://playwright.dev/python/docs/test-assertions)
- Add a few helper fixtures in user tests where test class setup was providing repeat data previously
- Updates docs around testing
- Updates CircleCI config to use pytest

### `pyproject.toml`
- Swap `pyproject.toml` author info with cookiecutter placeholders
- Update `pyproject.toml` to use newer style Poetry dependency groups
- Ran through a YAML formatter
- Add pytest config