### PR TITLE
Increase test settings priority

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -167,9 +167,8 @@ profile = "django"
 indent = 2
 
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "{{cookiecutter.repo_name}}.config.settings.test"
 python_files = ["tests.py", "test_*.py", "*_tests.py"]
-addopts = ["--reuse-db"]
+addopts = ["--reuse-db", "--ds={{cookiecutter.repo_name}}.config.settings.test"]
 
 [tool.cruft]
 skip = [".git", "node_modules"]


### PR DESCRIPTION
This forces pytest-django to run using test settings for pytest runs over any other settings configured in .env or environment variables.

https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings