### PR TITLE
Title fixes

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/account_base.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/account_base.jinja
@@ -1,5 +1,8 @@
 {% from 'account/components/account_box.jinja' import account_box %}
 {% extends "base.jinja" %}
+{% block title %}
+    Account
+{% endblock title %}
 
 {% set account_back %}
 {% block account_back %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
@@ -11,8 +11,8 @@
         {{ vite_asset('css/base.js') }}
         {{ vite_asset('js/main.ts') }}
         {{ django_htmx_script() }}
+        <title>{% block title required %}{% endblock title %} - Lightmatter</title>
         {% block extra_head %}
-            <title>Lightmatter</title>
         {% endblock extra_head %}
     </head>
     <body hx-boost="true"

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/index.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/index.jinja
@@ -1,6 +1,6 @@
 {% extends "base.jinja" %}
 {% block title %}
-    Lightmatter Base Install
+    Index
 {% endblock title %}
 {% block content %}
     <div class="container mx-auto">


### PR DESCRIPTION
Many templates had a title block, but the base template had nowhere for those blocks to land.

- Move the title block out of `extra_head` so it can't be accidentally overridden
- Make the title block required for all children
- Add some composition logic for titles ("Page title - Site name")
- Clean up a few titles