### PR TITLE
Cancel redundant CI workflows

### DIFF
--- a/.github/workflows/project_ci.yml
+++ b/.github/workflows/project_ci.yml
@@ -8,6 +8,10 @@
 name: Project CI
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_and_test_project:
     name: Create and test Django project

--- a/{{cookiecutter.repo_name}}/.github/workflows/django_ci.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/django_ci.yml
@@ -4,6 +4,10 @@
 name: Django CI{% raw %}
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # # uncomment when using docker
   # docker:


### PR DESCRIPTION
If you push to the same branch consecutively, this'll cancel the first build (of the same workflow) if it's still running, saving CI time.