### PR TITLE
busting cache for local development

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -103,3 +103,10 @@ CACHALOT_UNCACHABLE_TABLES = frozenset(
 CSP_DEFAULT_SRC = ["'self'", f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}", f"ws://localhost:{DJANGO_VITE_DEV_SERVER_PORT}"]
 CSP_SCRIPT_SRC += [f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}", "cdn.jsdelivr.net"]
 CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}"]
+
+# Local development template caching fix
+# Issue reference:
+# https://github.com/pallets/jinja/issues/253#issuecomment-1052871750
+options["cache_size"] = 0 if DEBUG else 400
+
+TEMPLATES[0]["OPTIONS"] = options

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -1,6 +1,7 @@
 # pylint: skip-file
 from .base import *  # noqa
 from .base import env
+from ..jinja2 import options
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -100,7 +101,11 @@ CACHALOT_UNCACHABLE_TABLES = frozenset(
     )
 )
 
-CSP_DEFAULT_SRC = ["'self'", f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}", f"ws://localhost:{DJANGO_VITE_DEV_SERVER_PORT}"]
+CSP_DEFAULT_SRC = [
+    "'self'",
+    f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}",
+    f"ws://localhost:{DJANGO_VITE_DEV_SERVER_PORT}",
+]
 CSP_SCRIPT_SRC += [f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}", "cdn.jsdelivr.net"]
 CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", f"localhost:{DJANGO_VITE_DEV_SERVER_PORT}"]
 


### PR DESCRIPTION
Local development has issues with imported jinja files not being included in updated changes until you kill your server and restart it. This fixes that for local development only