### PR TITLE
Set max conn age to zero

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -115,3 +115,12 @@ CSP_STYLE_SRC = ["'self'", "'unsafe-inline'", f"localhost:{DJANGO_VITE_DEV_SERVE
 options["cache_size"] = 0 if DEBUG else 400
 
 TEMPLATES[0]["OPTIONS"] = options
+
+# see: https://code.djangoproject.com/ticket/33497
+# see: https://github.com/Lightmatter/htn/pull/77
+# Ideally this should be zero in all setups, but there have been reports from other projects
+# that that cuases rendering issues
+#
+# Bandaid fix until the django project puts in an offical patch
+# Unclear at this time why prod + dev hosts do not experience any issues with this
+DATABASES["default"]["CONN_MAX_AGE"] = 0  # noqa F405


### PR DESCRIPTION
Fixes the too many conns issue as discussed in the [htn chat](https://lightmatter.slack.com/archives/C046P95JC06/p1674066342791679), the [hydra chat](https://lightmatter.slack.com/archives/C0L7RV56G/p1674068176235759?thread_ts=1674068034.858719&cid=C0L7RV56G), and fixed in the [htn project](https://github.com/Lightmatter/htn/pull/77)

Brian has also confirmed that this fix works on farewellfax.


This bug only affect local development setups (for some reason)