### PR TITLE
HYD-16 Frontend Validation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,8 +9,8 @@
   "domain_name": "example.com",
   "version": "0.1.0",
   "_copy_without_render": [
-    "{{cookiecutter.repo_name}}/templates/**/*.html",
-    "{{cookiecutter.repo_name}}/templates/**/*.jinja",
+    "{{cookiecutter.repo_name}}/**/*.jinja",
+    "{{cookiecutter.repo_name}}/**/*.html",
     "{{cookiecutter.repo_name}}/templates/**/*.txt"
   ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,9 +9,8 @@
   "domain_name": "example.com",
   "version": "0.1.0",
   "_copy_without_render": [
-    "*.html",
-    "templates/**/*.txt",
-    "*.jinja",
-    ".yarn/*"
+    "{{cookiecutter.repo_name}}/templates/**/*.html",
+    "{{cookiecutter.repo_name}}/templates/**/*.jinja",
+    "{{cookiecutter.repo_name}}/templates/**/*.txt"
   ]
 }

--- a/{{cookiecutter.repo_name}}/.cookiecutter.json
+++ b/{{cookiecutter.repo_name}}/.cookiecutter.json
@@ -2,9 +2,8 @@
   "project_name_verbose": "{{cookiecutter.project_name_verbose}}",
   "repo_name": "{{cookiecutter.repo_name}}",
   "_copy_without_render": [
-    "*.html",
-    "templates/**/*.txt",
-    "*.jinja",
-    ".yarn/*"
-]
+    "{{cookiecutter.repo_name}}/templates/**/*.html",
+    "{{cookiecutter.repo_name}}/templates/**/*.jinja",
+    "{{cookiecutter.repo_name}}/templates/**/*.txt"
+  ]
 }

--- a/{{cookiecutter.repo_name}}/.cookiecutter.json
+++ b/{{cookiecutter.repo_name}}/.cookiecutter.json
@@ -2,8 +2,8 @@
   "project_name_verbose": "{{cookiecutter.project_name_verbose}}",
   "repo_name": "{{cookiecutter.repo_name}}",
   "_copy_without_render": [
-    "{{cookiecutter.repo_name}}/templates/**/*.html",
-    "{{cookiecutter.repo_name}}/templates/**/*.jinja",
+    "{{cookiecutter.repo_name}}/**/*.jinja",
+    "{{cookiecutter.repo_name}}/**/*.html",
     "{{cookiecutter.repo_name}}/templates/**/*.txt"
   ]
 }

--- a/{{cookiecutter.repo_name}}/.eslintrc.js
+++ b/{{cookiecutter.repo_name}}/.eslintrc.js
@@ -6,8 +6,8 @@ module.exports = {
   },
   "extends": [
     "plugin:@typescript-eslint/recommended",
-    //TODO: Fix typechecking issues in main.ts and util to use this
-    //'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    // TODO: Fix typechecking issues in main.ts and util to use this
+    // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
     "airbnb-base",
   ],
   "parserOptions": {

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -164,8 +164,11 @@ max-line-length = 139
 
 [tool.djlint]
 ignore = ["H006", "H023", "T002"]
-profile = "django"
+profile = "jinja"
 indent = 2
+max_line_length=92
+max_attribute_length=6
+use_gitignore=true
 
 [tool.pytest.ini_options]
 python_files = ["tests.py", "test_*.py", "*_tests.py"]

--- a/{{cookiecutter.repo_name}}/tsconfig.json
+++ b/{{cookiecutter.repo_name}}/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
-    "types": [
-      "vite/client"
-    ],
+    "types": ["vite/client"],
     "target": "es6",
     "useDefineForClassFields": true,
     "module": "esnext",
@@ -12,10 +10,19 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "lib": [
-      "esnext",
-      "dom"
-    ],
+    "lib": ["esnext", "dom"]
   },
-  "include": ["{{cookiecutter.repo_name}}/static_source/**/*.ts", "{{cookiecutter.repo_name}}/static_source/**/*.d.ts", "{{cookiecutter.repo_name}}/static_source/**/*.tsx", "{{cookiecutter.repo_name}}/static_source/**/*.vue", "{{cookiecutter.repo_name}}/static_source/**/*.js"]
+  "include": [
+    ".*.js",
+    "{{cookiecutter.repo_name}}/static_source/**/*.ts",
+    "{{cookiecutter.repo_name}}/static_source/**/*.d.ts",
+    "{{cookiecutter.repo_name}}/static_source/**/*.tsx",
+    "{{cookiecutter.repo_name}}/static_source/**/*.vue",
+    "{{cookiecutter.repo_name}}/static_source/**/*.js",
+    "{{cookiecutter.repo_name}}/templates/**/*.ts",
+    "{{cookiecutter.repo_name}}/templates/**/*.d.ts",
+    "{{cookiecutter.repo_name}}/templates/**/*.tsx",
+    "{{cookiecutter.repo_name}}/templates/**/*.vue",
+    "{{cookiecutter.repo_name}}/templates/**/*.js"
+  ]
 }

--- a/{{cookiecutter.repo_name}}/vite.config.js
+++ b/{{cookiecutter.repo_name}}/vite.config.js
@@ -8,17 +8,17 @@ export default defineConfig({
   root: resolve('./{{cookiecutter.repo_name}}/static_source/'),
   // The public path where assets are served, both in development and in production.
   base: "/static/",
-  resolve:{
-    alias:{
+  resolve: {
+    alias: {
       // Use '@' in urls as a shortcut for './static_source'. (Currently used in CSS files.)
-      '@' : resolve('./{{cookiecutter.repo_name}}/static_source')
+      '@': resolve('./{{cookiecutter.repo_name}}/static_source')
     },
   },
   build: {
     manifest: true, // adds a manifest.json
     rollupOptions: {
       input: {
-        /* The bundle's entry point(s).  If you provide an array of entry points or an object mapping names to 
+        /* The bundle's entry point(s).  If you provide an array of entry points or an object mapping names to
         entry points, they will be bundled to separate output chunks. */
         components: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/components.ts'),
         account: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/account.ts'),
@@ -29,19 +29,19 @@ export default defineConfig({
         raw_tailwind: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/css/tailwind.js'),
       }
     },
-    outDir:  './', // puts the manifest.json in PROJECT_ROOT/static_source/ for Django to collect
+    outDir: './', // puts the manifest.json in PROJECT_ROOT/static_source/ for Django to collect
   },
   plugins: [
     {
       name: 'watch-external', // https://stackoverflow.com/questions/63373804/rollup-watch-include-directory/63548394#63548394
-      async buildStart(){
+      async buildStart() {
         const htmls = await fg(['{{cookiecutter.repo_name}}/templates/**/*.html']);
-        for(let file of htmls){
+        for (let file of htmls) {
           this.addWatchFile(file);
         }
 
         const jinjas = await fg(['{{cookiecutter.repo_name}}/templates/**/*.jinja']);
-        for(let file of jinjas){
+        for (let file of jinjas) {
           this.addWatchFile(file);
         }
       }
@@ -49,7 +49,7 @@ export default defineConfig({
     {
       name: 'reloadHtml',
       handleHotUpdate({ file, server }) {
-        if (file.endsWith('.html') || file.endsWith('.jinja') ){
+        if (file.endsWith('.html') || file.endsWith('.jinja')) {
           server.ws.send({
             type: 'custom',
             event: 'template-hmr',

--- a/{{cookiecutter.repo_name}}/vite.config.js
+++ b/{{cookiecutter.repo_name}}/vite.config.js
@@ -21,6 +21,8 @@ export default defineConfig({
         /* The bundle's entry point(s).  If you provide an array of entry points or an object mapping names to 
         entry points, they will be bundled to separate output chunks. */
         components: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/components.ts'),
+        account: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/account.ts'),
+        forms: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/forms.ts'),
         main: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/main.ts'),
         links: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/links.ts'),
         styles: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/css/styles.js'),

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/atoms/inputs.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/atoms/inputs.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable no-descending-specificity */
 
-
 $input-height: 50px;
 
 .form-wrapper {
@@ -43,7 +42,8 @@ $input-height: 50px;
     border-color: var(--primary-accent);
   }
 
-  > .input-box { // div with styling hook
+  > .input-box {
+    // div with styling hook
     @apply mx-4 flex items-center;
 
     height: 100%;
@@ -61,7 +61,6 @@ $input-height: 50px;
       transform: translate(0, -250%) scale(0.75);
       max-width: 130%;
     }
-
 
     @mixin label-resting {
       transform-origin: top left;
@@ -83,7 +82,6 @@ $input-height: 50px;
     textarea + label {
       @include label-resting;
     }
-
 
     input:focus + label,
     .ts-wrapper.focus + label,
@@ -110,11 +108,13 @@ $input-height: 50px;
     }
 
     // firefox does not support has queries, so turn off the label behavior there
-    .password:has(input) + label {
+    .password:has(input) + label,
+    .input:has(input) + label {
       @include label-resting;
     }
 
-    .password:has(input:focus) + label {
+    .password:has(input:focus) + label,
+    .input:has(input:focus) + label {
       @include label-focused;
     }
 
@@ -122,20 +122,26 @@ $input-height: 50px;
     .password:has(input:not(:placeholder-shown)) + label,
     .password:has(input:-webkit-autofill) + label,
     .password:has(input:-webkit-autofill:hover) + label,
-    .password:has(input:-webkit-autofill:focus) + label, {
+    .password:has(input:-webkit-autofill:focus) + label,
+    .input:has(input:focus) + label,
+    .input:has(input:not(:placeholder-shown)) + label,
+    .input:has(input:-webkit-autofill) + label,
+    .input:has(input:-webkit-autofill:hover) + label,
+    .input:has(input:-webkit-autofill:focus) + label {
       @include label-transition;
     }
 
     @-moz-document url-prefix() {
-      .password + label {
+      .password + label,
+      .input + label {
         display: none;
       }
 
-      .password input::placeholder {
+      .password input::placeholder,
+      .input input::placeholder {
         color: var(--slate);
       }
     }
-
 
     .ts-wrapper {
       @apply ring-0;
@@ -178,7 +184,6 @@ $input-height: 50px;
     textarea {
       @apply px-0 ring-0;
 
-      padding-right: 22px;
       width: 100%;
       height: 50px;
       border-radius: 5px;
@@ -192,6 +197,16 @@ $input-height: 50px;
 
       &:focus {
         padding-top: 20px;
+      }
+
+      @-moz-document url-prefix() {
+        &:not(:placeholder-shown) {
+          padding-top: 8px;
+        }
+
+        &:focus {
+          padding-top: 8px;
+        }
       }
     }
 
@@ -214,7 +229,6 @@ $input-height: 50px;
       font-size: inherit;
     }
 
-
     label {
       @apply absolute pointer-events-none block;
 
@@ -223,7 +237,8 @@ $input-height: 50px;
       pointer-events: none;
       top: 0;
       line-height: $input-height;
-      transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms, transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+      transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+      transform: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
       color: var(--slate);
     }
   }
@@ -296,7 +311,6 @@ $input-height: 50px;
     }
   }
 }
-
 
 .left-icon {
   @apply absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/account.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/account.ts
@@ -1,0 +1,2 @@
+import.meta.glob("@/../templates/account/**/*.js", { eager: true });
+import.meta.glob("@/../templates/account/**/*.ts", { eager: true });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/components.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/components.ts
@@ -1,3 +1,2 @@
 import.meta.glob("@/../templates/components/**/*.js", { eager: true });
 import.meta.glob("@/../templates/components/**/*.ts", { eager: true });
-

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/forms.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/forms.ts
@@ -1,0 +1,2 @@
+import.meta.glob("@/../templates/forms/**/*.js", { eager: true });
+import.meta.glob("@/../templates/forms/**/*.ts", { eager: true });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/index.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/index.ts
@@ -1,0 +1,3 @@
+import { AlpineComponent } from "alpinejs";
+
+export type AlpineDataCallback = (...initialStateArgs: unknown[]) => AlpineComponent

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.jinja
@@ -1,5 +1,8 @@
 {% from 'forms/field.jinja' import field as f %}
-<div class="form-wrapper gap-x-6 justify-between">
+<div x-data="signup()"
+     x-on:update-id-password1="password1 = $event.detail.value"
+     x-on:update-id-password2="password2 = $event.detail.value"
+     class="form-wrapper gap-x-6 justify-between">
     {{ errors }}
     {% for field, errors in fields %}
         {% if field.name == 'first_name' or field.name == 'last_name' %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
@@ -1,49 +1,47 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
 
-function signup(): AlpineComponent {
-  return {
-    password1: "",
-    password2: "",
-    pMatchError: "Passwords must match",
-    p2OriginalError: "",
-    get passwordMatch(): boolean {
-      return (this.password1 === "" || this.password2 === "")
-        || this.password1 === this.password2;
-    },
-    toggleError() {
-      const p2 = this.$el.querySelector("#id_password2");
-      const p2Field = p2?.closest(".field");
-      const p2ErrorIcon = p2?.closest(".input-box")?.querySelector(".right-icon");
-      const p2ErrorLabel = p2Field?.parentElement?.querySelector("div.text-error");
+const signup = (): AlpineComponent => ({
+  password1: "",
+  password2: "",
+  pMatchError: "Passwords must match",
+  p2OriginalError: "",
+  get passwordMatch(): boolean {
+    return (this.password1 === "" || this.password2 === "")
+      || this.password1 === this.password2;
+  },
+  toggleError() {
+    const p2 = this.$el.querySelector("#id_password2");
+    const p2Field = p2?.closest(".field");
+    const p2ErrorIcon = p2?.closest(".input-box")?.querySelector(".right-icon");
+    const p2ErrorLabel = p2Field?.parentElement?.querySelector("div.text-error");
 
-      if (this.passwordMatch) {
-        if (p2ErrorLabel) {
-          p2ErrorLabel.innerHTML = this.p2OriginalError;
-        }
-        p2Field?.classList?.remove("error");
-        p2ErrorIcon?.classList?.add("hidden");
-        p2ErrorLabel?.classList?.add("hidden");
-      } else {
-        if (p2ErrorLabel) {
-          p2ErrorLabel.innerHTML = this.pMatchError;
-        }
-        p2Field?.classList?.add("error");
-        p2ErrorIcon?.classList?.remove("hidden");
-        p2ErrorLabel?.classList?.remove("hidden");
+    if (this.passwordMatch) {
+      if (p2ErrorLabel) {
+        p2ErrorLabel.innerHTML = this.p2OriginalError;
       }
-    },
-    init() {
-      this.$watch("passwordMatch", () => {
-        this.toggleError();
-      });
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.p2OriginalError = this.$el.querySelector("#id_password2")!
-        .closest(".field")!
-        .parentElement!
-        .querySelector("div.text-error")!
-        .innerHTML;
-    },
-  }
-};
+      p2Field?.classList?.remove("error");
+      p2ErrorIcon?.classList?.add("hidden");
+      p2ErrorLabel?.classList?.add("hidden");
+    } else {
+      if (p2ErrorLabel) {
+        p2ErrorLabel.innerHTML = this.pMatchError;
+      }
+      p2Field?.classList?.add("error");
+      p2ErrorIcon?.classList?.remove("hidden");
+      p2ErrorLabel?.classList?.remove("hidden");
+    }
+  },
+  init() {
+    this.$watch("passwordMatch", () => {
+      this.toggleError();
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.p2OriginalError = this.$el.querySelector("#id_password2")!
+      .closest(".field")!
+      .parentElement!
+      .querySelector("div.text-error")!
+      .innerHTML;
+  },
+});
 
 AlpineInstance.data("signup", signup);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
@@ -1,48 +1,49 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
 
-const signup = (): AlpineComponent => ({
-  // Data
-  password1: "",
-  password2: "",
-  pMatchError: "Passwords must match",
-  p2OriginalError: "",
-  get passwordMatch(): boolean {
-    return (this.password1 === "" || this.password2 === "")
-      || this.password1 === this.password2;
-  },
-  toggleError() {
-    const p2 = this.$el.querySelector("#id_password2");
-    const p2Field = p2?.closest(".field");
-    const p2ErrorIcon = p2?.closest(".input-box")?.querySelector(".right-icon");
-    const p2ErrorLabel = p2Field?.parentElement?.querySelector("div.text-error");
+function signup(): AlpineComponent {
+  return {
+    password1: "",
+    password2: "",
+    pMatchError: "Passwords must match",
+    p2OriginalError: "",
+    get passwordMatch(): boolean {
+      return (this.password1 === "" || this.password2 === "")
+        || this.password1 === this.password2;
+    },
+    toggleError() {
+      const p2 = this.$el.querySelector("#id_password2");
+      const p2Field = p2?.closest(".field");
+      const p2ErrorIcon = p2?.closest(".input-box")?.querySelector(".right-icon");
+      const p2ErrorLabel = p2Field?.parentElement?.querySelector("div.text-error");
 
-    if (this.passwordMatch) {
-      if (p2ErrorLabel) {
-        p2ErrorLabel.innerHTML = this.p2OriginalError;
+      if (this.passwordMatch) {
+        if (p2ErrorLabel) {
+          p2ErrorLabel.innerHTML = this.p2OriginalError;
+        }
+        p2Field?.classList?.remove("error");
+        p2ErrorIcon?.classList?.add("hidden");
+        p2ErrorLabel?.classList?.add("hidden");
+      } else {
+        if (p2ErrorLabel) {
+          p2ErrorLabel.innerHTML = this.pMatchError;
+        }
+        p2Field?.classList?.add("error");
+        p2ErrorIcon?.classList?.remove("hidden");
+        p2ErrorLabel?.classList?.remove("hidden");
       }
-      p2Field?.classList?.remove("error");
-      p2ErrorIcon?.classList?.add("hidden");
-      p2ErrorLabel?.classList?.add("hidden");
-    } else {
-      if (p2ErrorLabel) {
-        p2ErrorLabel.innerHTML = this.pMatchError;
-      }
-      p2Field?.classList?.add("error");
-      p2ErrorIcon?.classList?.remove("hidden");
-      p2ErrorLabel?.classList?.remove("hidden");
-    }
-  },
-  init() {
-    this.$watch("passwordMatch", () => {
-      this.toggleError();
-    });
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.p2OriginalError = this.$el.querySelector("#id_password2")!
-      .closest(".field")!
-      .parentElement!
-      .querySelector("div.text-error")!
-      .innerHTML;
-  },
-});
+    },
+    init() {
+      this.$watch("passwordMatch", () => {
+        this.toggleError();
+      });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.p2OriginalError = this.$el.querySelector("#id_password2")!
+        .closest(".field")!
+        .parentElement!
+        .querySelector("div.text-error")!
+        .innerHTML;
+    },
+  }
+};
 
 AlpineInstance.data("signup", signup);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/account/signup_form.ts
@@ -1,0 +1,48 @@
+import AlpineInstance, { AlpineComponent } from "alpinejs";
+
+const signup = (): AlpineComponent => ({
+  // Data
+  password1: "",
+  password2: "",
+  pMatchError: "Passwords must match",
+  p2OriginalError: "",
+  get passwordMatch(): boolean {
+    return (this.password1 === "" || this.password2 === "")
+      || this.password1 === this.password2;
+  },
+  toggleError() {
+    const p2 = this.$el.querySelector("#id_password2");
+    const p2Field = p2?.closest(".field");
+    const p2ErrorIcon = p2?.closest(".input-box")?.querySelector(".right-icon");
+    const p2ErrorLabel = p2Field?.parentElement?.querySelector("div.text-error");
+
+    if (this.passwordMatch) {
+      if (p2ErrorLabel) {
+        p2ErrorLabel.innerHTML = this.p2OriginalError;
+      }
+      p2Field?.classList?.remove("error");
+      p2ErrorIcon?.classList?.add("hidden");
+      p2ErrorLabel?.classList?.add("hidden");
+    } else {
+      if (p2ErrorLabel) {
+        p2ErrorLabel.innerHTML = this.pMatchError;
+      }
+      p2Field?.classList?.add("error");
+      p2ErrorIcon?.classList?.remove("hidden");
+      p2ErrorLabel?.classList?.remove("hidden");
+    }
+  },
+  init() {
+    this.$watch("passwordMatch", () => {
+      this.toggleError();
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.p2OriginalError = this.$el.querySelector("#id_password2")!
+      .closest(".field")!
+      .parentElement!
+      .querySelector("div.text-error")!
+      .innerHTML;
+  },
+});
+
+AlpineInstance.data("signup", signup);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
@@ -1,26 +1,32 @@
 <!DOCTYPE HTML>
 <html lang="en">
     <head>
-        <meta charset="utf-8" />
-        <meta name="description" content="" />
-        <meta name="keywords" content="" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+        <meta charset="utf-8"/>
+        <meta name="description"
+              content=""/>
+        <meta name="keywords"
+              content=""/>
+        <meta http-equiv="x-ua-compatible"
+              content="ie=edge"/>
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1.0"/>
         {% block opengraph %}
             {% from 'components/open_graph_tags.jinja' import og_tags %}
-            {{og_tags(title="TODO | Home", url="TODO", description="TODO", image_url="TODO")}}
-        {% endblock %}
-
+            {{ og_tags(title="TODO | Home", url="TODO", description="TODO", image_url="TODO")}}
+        {% endblock opengraph %}
         <link rel="icon" href={{ static("img/favicons/favicon.ico") }} />
-
         {{ vite_hmr_client() }}
         {{ vite_asset('css/styles.js') }}
+        {{ vite_asset('js/account.ts') }}
         {{ vite_asset('js/components.ts') }}
+        {{ vite_asset('js/forms.ts') }}
         {{ vite_asset('js/links.ts') }}
         {{ vite_asset('js/main.ts') }}
         {{ django_htmx_script() }}
-        <title>{% block title required %}{% endblock title %} - Lightmatter</title>
+        <title>
+            {% block title required %}
+            {% endblock title %}
+        - Lightmatter</title>
         {% block extra_head %}
         {% endblock extra_head %}
     </head>
@@ -32,7 +38,8 @@
         <div id="app">
             {% block content %}
             {% endblock content %}
-            <ul class="messages" id="messages">
+            <ul class="messages"
+                id="messages">
                 {% include "util/messages.jinja" %}
             </ul>
         </div>

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
@@ -1,7 +1,7 @@
 {# different widgets could use totally different base styles, leave a hook to control #}
 {# or Sometimes third party controls come with their own styling, so for these widgets do not style #}
-{%-  macro input_widget_hook(field) -%}
-    {%- if field.widget_type == "select"  -%}
+{%- macro input_widget_hook(field) -%}
+    {%- if field.widget_type == "select" -%}
         select
     {%- elif field.widget_type == "radioselect" -%}
         radio
@@ -9,55 +9,44 @@
         input
     {%- endif -%}
 {%- endmacro -%}
-
 {% macro input_shell(field, errors='') %}
-    <div class="field {% if errors %} error{% endif %}">
+    <div class="field {% if errors %}error{% endif %}">
         <div class="input-box {{ input_widget_hook(field) }}">
-        {{ field }}
-        {% if field.label %}{{ field.label_tag() }}{% endif %}
-        {% if errors %}
-            <div class="right-icon">
-                {{heroicon_solid("exclamation-circle", class="text-error")}}
+            {{ field }}
+            {% if field.label %}{{ field.label_tag() }}{% endif %}
+            <div class="right-icon {% if errors is not none %}hidden{% endif %}">
+                {{ heroicon_solid("exclamation-circle", class="text-error")}}
             </div>
-        {% endif %}
         </div>
     </div>
 {% endmacro %}
-
 {% macro boolean_shell(field, errors='') %}
-    <div class="boolean-field flex items-center {% if errors %}error{% endif %}">
+    <div class="boolean-field flex items-center {% if errors %} error{% endif %}">
         {% if field.label %}{{ field.label_tag() }}{% endif %}
         {{ field }}
     </div>
 {% endmacro %}
-
 {% macro radio_shell(field, errors='') %}
     <div class="radio-field {% if errors %} error{% endif %}">
-        <div class="{{ input_widget_hook(field) }}">
-        {{ field }}
-        </div>
+        <div class="{{ input_widget_hook(field) }}">{{ field }}</div>
     </div>
 {% endmacro %}
-
 {% macro field(field, errors='', layout_classes='w-full') %}
     {% set wrapper_element = "fieldset" if field.widget_type == "radioselect" else "div" %}
     <{{ wrapper_element }} class="{{ layout_classes }} {{ field.css_classes() }}">
-        {% if field.widget_type == "toggle" %}
-            {{boolean_shell(field, errors)}}
-        {% elif field.widget_type == "radioselect" %}
-            <legend>{{ field.label }}</legend>
-            {{radio_shell(field, errors)}}
-        {% else %}
-            {{input_shell(field, errors)}}
-        {% endif %}
-        {% if errors %}
-            <div class="text-error">
-                {{ errors }}
-            </div>
-        {% elif field.help_text %}
-            <p class="text-sm text-gray-500" id="email-description">
-                {{ field.help_text|safe }}
-            </p>
-        {% endif %}
+    {% if field.widget_type == "toggle" %}
+        {{ boolean_shell(field, errors)}}
+    {% elif field.widget_type == "radioselect" %}
+        <legend>
+            {{ field.label }}
+        </legend>
+        {{ radio_shell(field, errors)}}
+    {% else %}
+        {{ input_shell(field, errors)}}
+    {% endif %}
+    <div class="text-error {% if errors is not none %}hidden{% endif %}">{{ errors }}</div>
+    {% if field.help_text %}
+        <p class="text-sm text-gray-500">{{ field.help_text|safe }}</p>
+    {% endif %}
     </{{ wrapper_element }}>
 {% endmacro %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
@@ -1,15 +1,13 @@
 {% from 'components/util.jinja' import attributes %}
-
-{% macro input(type="text", name=none, value=none, model="input", color='primary', attrs={}, left_icon='', right_icon='') %}
+{% macro input(type="text", name=none, value=none, event_name="", color='primary', attrs={}, left_icon='', right_icon='') %}
     {% set disabled, readonly = attrs.disabled, attrs.readonly %}
     {% set noedit = disabled or readonly %}
-    <input
-        {% set _ = attrs.update({"type": type, "name": name, "value": value}) %}
-        {{attributes(attrs)}}
-    />
+    <div x-data="input('update-{{ event_name | replace('_', '-') }}', '{{ value }}')"
+         class="w-full input">
+        <input x-model.debounce.500ms="value" {% set _ = attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
+    </div>
 {% endmacro %}
-
 {# takes a django widget and calls our input macro with the appropriate args #}
 {% macro widget_to_input(widget) %}
-    {{ input(type=widget.type, name=widget.name, value=widget.value, model=widget.attrs.id, attrs=widget.attrs )}}
+    {{ input(type=widget.type, name=widget.name, value=widget.value, event_name=widget.attrs.id, attrs=widget.attrs )}}
 {% endmacro %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
@@ -1,0 +1,22 @@
+import AlpineInstance, { AlpineComponent } from "alpinejs";
+
+const input = (...args: unknown[]): AlpineComponent => ({
+  // Props
+  eventName: args[0] as string,
+  value: args[1] as string,
+  init() {
+    if (this.value === "None") {
+      this.value = "";
+    }
+    if (this.eventName !== "input") {
+      this.$watch("value", () => {
+        this.$dispatch(
+          this.eventName,
+          { value: this.value },
+        );
+      });
+    }
+  },
+});
+
+AlpineInstance.data("input", input);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
@@ -1,23 +1,22 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
+import { AlpineDataCallback } from "../../static_source/js";
 
-function input(eventName: string, value: string): AlpineComponent {
-  return {
-    eventName,
-    value,
-    init() {
-      if (this.value === "None") {
-        this.value = "";
-      }
-      if (this.eventName !== "input") {
-        this.$watch("value", () => {
-          this.$dispatch(
-            this.eventName,
-            { value: this.value },
-          );
-        });
-      }
-    },
-  };
-}
+const input = (eventName: string, value: string): AlpineComponent => ({
+  eventName,
+  value,
+  init() {
+    if (this.value === "None") {
+      this.value = "";
+    }
+    if (this.eventName !== "input") {
+      this.$watch("value", () => {
+        this.$dispatch(
+          this.eventName,
+          { value: this.value },
+        );
+      });
+    }
+  },
+});
 
-AlpineInstance.data("input", input);
+AlpineInstance.data("input", input as AlpineDataCallback);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
@@ -1,22 +1,23 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
 
-const input = (...args: unknown[]): AlpineComponent => ({
-  // Props
-  eventName: args[0] as string,
-  value: args[1] as string,
-  init() {
-    if (this.value === "None") {
-      this.value = "";
-    }
-    if (this.eventName !== "input") {
-      this.$watch("value", () => {
-        this.$dispatch(
-          this.eventName,
-          { value: this.value },
-        );
-      });
-    }
-  },
-});
+function input(eventName: string, value: string): AlpineComponent {
+  return {
+    eventName,
+    value,
+    init() {
+      if (this.value === "None") {
+        this.value = "";
+      }
+      if (this.eventName !== "input") {
+        this.$watch("value", () => {
+          this.$dispatch(
+            this.eventName,
+            { value: this.value },
+          );
+        });
+      }
+    },
+  };
+}
 
 AlpineInstance.data("input", input);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
@@ -1,26 +1,21 @@
 {% from 'components/util.jinja' import attributes %}
-
-{% macro password(name='password', value=None, model="password", attrs={}) %}
-    <div x-data="{input: 'password'}" class="w-full flex items-center relative password">
-        <input :type="input"
-            name="{{ name }}"
-            class="mr-8"
-            {% if value != None %} value="{{ value }}"{% endif %}
-            {{attributes(attrs)}}>
+{% macro password(name='password', value=None, event_name="", attrs={}) %}
+    <div x-data="password('update-{{ event_name | replace('_', '-') }}', '{{ value }}', 'password')"
+         class="w-full flex items-center relative password">
+        <input x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
         <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
-            @click="input='password'"
-            x-cloak
-            x-show="input==='text'">
+             @click="type='password'"
+             x-cloak
+             x-show="type==='text'">
             {{ heroicon_outline("eye-slash", class="w-6 h-6") }}
         </div>
         <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
-            @click="input='text'"
-            x-show="input==='password'">
+             @click="type='text'"
+             x-show="type==='password'">
             {{ heroicon_outline("eye", class="w-6 h-6") }}
         </div>
     </div>
 {% endmacro %}
-
 {% macro widget_to_password(widget) %}
-    {{password(name=widget.name, value=widget.value, model=widget.attrs.id, attrs=widget.attrs )}}
+    {{ password(name=widget.name, value=widget.value, event_name=widget.attrs.id, attrs=widget.attrs )}}
 {% endmacro %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
@@ -1,23 +1,24 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
 
-const password = (...args: unknown[]): AlpineComponent => ({
-  // Props
-  eventName: args[0] as string,
-  value: args[1] as string,
-  type: args[2] as string,
-  init() {
-    if (this.value === "None") {
-      this.value = "";
-    }
-    if (this.eventName !== "") {
-      this.$watch("value", () => {
-        this.$dispatch(
-          this.eventName,
-          { value: this.value },
-        );
-      });
-    }
-  },
-});
+function password(eventName: string, value: string, type: string): AlpineComponent {
+  return {
+    eventName,
+    value,
+    type,
+    init() {
+      if (this.value === "None") {
+        this.value = "";
+      }
+      if (this.eventName !== "") {
+        this.$watch("value", () => {
+          this.$dispatch(
+            this.eventName,
+            { value: this.value },
+          );
+        });
+      }
+    },
+  };
+}
 
 AlpineInstance.data("password", password);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
@@ -1,0 +1,23 @@
+import AlpineInstance, { AlpineComponent } from "alpinejs";
+
+const password = (...args: unknown[]): AlpineComponent => ({
+  // Props
+  eventName: args[0] as string,
+  value: args[1] as string,
+  type: args[2] as string,
+  init() {
+    if (this.value === "None") {
+      this.value = "";
+    }
+    if (this.eventName !== "") {
+      this.$watch("value", () => {
+        this.$dispatch(
+          this.eventName,
+          { value: this.value },
+        );
+      });
+    }
+  },
+});
+
+AlpineInstance.data("password", password);

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
@@ -1,24 +1,23 @@
 import AlpineInstance, { AlpineComponent } from "alpinejs";
+import { AlpineDataCallback } from "../../static_source/js";
 
-function password(eventName: string, value: string, type: string): AlpineComponent {
-  return {
-    eventName,
-    value,
-    type,
-    init() {
-      if (this.value === "None") {
-        this.value = "";
-      }
-      if (this.eventName !== "") {
-        this.$watch("value", () => {
-          this.$dispatch(
-            this.eventName,
-            { value: this.value },
-          );
-        });
-      }
-    },
-  };
-}
+const password = (eventName: unknown, value: unknown, type: unknown): AlpineComponent => ({
+  eventName,
+  value,
+  type,
+  init() {
+    if (this.value === "None") {
+      this.value = "";
+    }
+    if (this.eventName !== "") {
+      this.$watch("value", () => {
+        this.$dispatch(
+          this.eventName,
+          { value: this.value },
+        );
+      });
+    }
+  },
+});
 
-AlpineInstance.data("password", password);
+AlpineInstance.data("password", password as AlpineDataCallback);


### PR DESCRIPTION
This PR exposes the values of text + password inputs to parent elements by way of events tied to the input's id. 

It also includes an example of how you would use this on the frontend by adding a password match check to the signup form shown below. This example is pretty complicated and would be a lot simpler if we just wanted to show a form-level warning instead of modifying the input styling.

<img width=500 src="https://user-images.githubusercontent.com/4155337/217555273-9d42d5d2-17c0-417c-8176-3fef6d16f794.gif" />
