### PR TITLE
rolls HTMX back to 1.8.5

### DIFF
--- a/{{cookiecutter.repo_name}}/package-lock.json
+++ b/{{cookiecutter.repo_name}}/package-lock.json
@@ -15,7 +15,7 @@
         "alpinejs": "^3.12.0",
         "flatpickr": "^4.6.13",
         "glob": "^9.2.1",
-        "htmx.org": "^1.8.6",
+        "htmx.org": "1.8.5",
         "js-cookie": "^3.0.1",
         "tom-select": "^2.2.1"
       },
@@ -3191,9 +3191,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.6.tgz",
-      "integrity": "sha512-88U8qwaIs4sZjzZvHgAX62B6qZoEdQNSYCRHARtYhSrk+iCUd3al8/0CrLwD8Tephsoodsf0gN9NbRrrmlJIfw=="
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.5.tgz",
+      "integrity": "sha512-3U9xraoaqNFCIUcpxD0EmF266ZS7DddTiraD9lqFORnsVnzmddAzi24ilaNyS4I9nhSj8tqiWbOf+ulKrU8bag=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -8242,9 +8242,9 @@
       "dev": true
     },
     "htmx.org": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.6.tgz",
-      "integrity": "sha512-88U8qwaIs4sZjzZvHgAX62B6qZoEdQNSYCRHARtYhSrk+iCUd3al8/0CrLwD8Tephsoodsf0gN9NbRrrmlJIfw=="
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.5.tgz",
+      "integrity": "sha512-3U9xraoaqNFCIUcpxD0EmF266ZS7DddTiraD9lqFORnsVnzmddAzi24ilaNyS4I9nhSj8tqiWbOf+ulKrU8bag=="
     },
     "iconv-lite": {
       "version": "0.6.3",

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -40,7 +40,7 @@
     "alpinejs": "^3.12.0",
     "flatpickr": "^4.6.13",
     "glob": "^9.2.1",
-    "htmx.org": "^1.8.6",
+    "htmx.org": "1.8.5",
     "js-cookie": "^3.0.1",
     "tom-select": "^2.2.1"
   }


### PR DESCRIPTION
this PR temporarily parks the template at HTMX version 1.8.5 while issues with 1.8.6 are investigated.