### PR TITLE
Fix isort install issue

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
 
   #python
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
         - id: isort
           exclude: .*migrations/.*

--- a/{{cookiecutter.repo_name}}/poetry.lock
+++ b/{{cookiecutter.repo_name}}/poetry.lock
@@ -776,14 +776,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.1.6"
+version = "4.1.7"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.1.6-py3-none-any.whl", hash = "sha256:c6fe7ebe7c017fe59f1029821dae0acb5a2ddcd6c9a0138fd20a8bfefac914bc"},
-    {file = "Django-4.1.6.tar.gz", hash = "sha256:bceb0fe1a386781af0788cae4108622756cd05e7775448deec04a71ddf87685d"},
+    {file = "Django-4.1.7-py3-none-any.whl", hash = "sha256:f2f431e75adc40039ace496ad3b9f17227022e8b11566f4b363da44c7e44761e"},
+    {file = "Django-4.1.7.tar.gz", hash = "sha256:44f714b81c5f190d9d2ddad01a532fe502fa01c4cb8faf1d081f4264ed15dcd8"},
 ]
 
 [package.dependencies]
@@ -3431,4 +3431,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "fe08b1fa1ba64210415fa141744137d0a7ca52e0a7712f53bfc7b9da4033faaa"
+content-hash = "4488728800c93651062bdfeb3cb4768afa0c0359d6b779c065b49e01c9201757"

--- a/{{cookiecutter.repo_name}}/poetry.lock
+++ b/{{cookiecutter.repo_name}}/poetry.lock
@@ -3307,15 +3307,18 @@ files = [
 
 [[package]]
 name = "werkzeug"
-version = "2.0.2"
+version = "2.2.3"
 description = "The comprehensive WSGI web application library."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "Werkzeug-2.0.2-py3-none-any.whl", hash = "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f"},
-    {file = "Werkzeug-2.0.2.tar.gz", hash = "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"},
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
 ]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog"]
@@ -3431,4 +3434,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4488728800c93651062bdfeb3cb4768afa0c0359d6b779c065b49e01c9201757"
+content-hash = "86f421bffdd76aae2ae59291d147dd94518aa9acfce783fdf85f2dc7d5ac4693"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -35,7 +35,7 @@ django-cors-headers = "^3.13.0"
 django-csp = "^3.7"
 
 [tool.poetry.group.dev.dependencies]
-Werkzeug = "2.0.2"
+Werkzeug = "2.2.3"
 coverage = {extras = ["toml"], version = "^6.4.1"}
 ipython = "^8.10.0"
 ipdb = "^0.13.9"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["{{cookiecutter.author_name}} <{{cookiecutter.email}}>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-Django = {extras = ["argon2"], version = "^4.1.6"}
+Django = {extras = ["argon2"], version = "^4.1.7"}
 whitenoise = {extras = ["brotli"], version = "^6.2.0"}
 django-allauth = "^0.51.0"
 django-htmx = "^1.8.0"


### PR DESCRIPTION
5.11.5 has a hotfix for this issue. Alternatively we can upgrade to 5.12 which also has a fix

## Error
![error](https://user-images.githubusercontent.com/32030464/228027820-be2c26c2-9bec-4270-bf60-737857469eec.png)


## Documented Issue && Fix
https://github.com/PyCQA/isort/issues/2077