### PR TITLE
Feature/update input styling

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -20,13 +20,8 @@ $border-color: var(--silver);
 $background-color: #fff;
 
 // label for focused input, Optionally can change the label color of focused element.
-@mixin label-focused($text-color:false) {
+@mixin label-focused {
   @apply top-0 left-0 pt-2 pb-2 text-xs leading-3;
-
-  @if $text-color {
-    color: $text-color;
-  }
-
   width: calc(100% - 0.75rem);
   background-color: $background-color;
 }
@@ -89,7 +84,7 @@ $background-color: #fff;
     // textarea handles vertical alignment differently from inputs,
     // so unique styling is needed.
     textarea {
-      @apply pt-4;
+      @apply pt-4 pr-3;
 
       line-height: calc($input-height / 2);
       height: $textarea-height;
@@ -119,15 +114,12 @@ $background-color: #fff;
       @include label-resting;
     }
 
-    .has-focus ~ label,
-    .ts-wrapper.focus + label {
-      @include label-focused($focus-label);
-    }
-
     .ts-wrapper.focus + label,
     .ts-wrapper.has-items + label,
     select:-webkit-autofill:hover + label,
-    select:-webkit-autofill:focus + label {
+    select:-webkit-autofill:focus + label,
+    .has-focus ~ label,
+    .ts-wrapper.focus + label {
       @include label-focused;
     }
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -21,7 +21,7 @@ $background-color: #fff;
 
 // label for focused input, Optionally can change the label color of focused element.
 @mixin label-focused {
-  @apply top-0 left-0 pt-2 pb-2 text-xs leading-3;
+  @apply top-0 left-0 pt-2 pb-1 text-xs leading-3;
   width: calc(100% - 0.75rem);
   background-color: $background-color;
 }
@@ -81,14 +81,6 @@ $background-color: #fff;
     &.textarea {
       @apply ml-4;
     }
-    // textarea handles vertical alignment differently from inputs,
-    // so unique styling is needed.
-    textarea {
-      @apply pt-4 pr-3;
-
-      line-height: calc($input-height / 2);
-      height: $textarea-height;
-    }
 
     input,
     textarea {
@@ -105,6 +97,15 @@ $background-color: #fff;
         @apply pointer-events-none;
 
       }
+    }
+
+    // textarea handles vertical alignment differently from inputs,
+    // so unique styling is needed.
+    textarea {
+      @apply pt-4 pr-3;
+
+      line-height: calc($input-height / 2);
+      height: $textarea-height;
     }
 
     .ts-wrapper + label,

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -1,28 +1,6 @@
 /* stylelint-disable no-descending-specificity */
-/* stylelint-disable at-rule-no-unknown */
 
-
-/*
-  This file controls the styling for "material" inputs.
-
-  Note: Animations will only display if the input includes a placeholder!
-  If your inputs appear to always be in the "focused" state, look there first.
-  Included is an optional js/components/material.ts file which will
-  replace empty placeholders with the adjacent input labels.
-
-  inputs are styled in the order of .field > .input-box > [input]
-  rem units are being used to keep things proportional, but we have a bit less
-  control over t-s (tom-select) which is being styled using px.
-*/
-
-// base guidelines for styles. All assume a base font size of 16
-$input-height: 3.75rem;                    // 60px
-$textarea-height: calc($input-height * 3); // replace with "auto" to default to HTML rows
-$border-radius: 0.5rem;                    // 8px
-$focus-color: var(--primary-focus);        // Outline of focused text elements
-$focus-label: var(--primary);              // color of focused label
-$border-color: var(--silver);
-$background-color: #fff;
+$input-height: 50px;
 
 .form-wrapper {
   @apply space-y-5 flex flex-row flex-wrap;
@@ -38,37 +16,18 @@ $background-color: #fff;
   }
 
   select ~ label {
-    z-index: 1;
+    z-index: 2;
   }
 }
 
+.field {
+  @apply mt-1;
 
-@mixin label-focused($text-color:false) {
-  @apply top-0 left-0 pt-2 pb-2 text-xs leading-3 w-full;
-
-  @if $text-color {
-    color: $text-color;
-  }
-  background-color: $background-color;
-}
-
-// label for empty, unfocused input.
-@mixin label-resting {
-  @apply text-left truncate max-w-full;
-  @apply absolute pointer-events-none block top-0 w-full overflow-hidden;
-
-  line-height: $input-height;
-  transition: all 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    background-color 0s ease-out 200ms;
-}
-
-.field { // wrapper element for input/label, provides basic styling for input
-  @apply border relative h-auto;
-
-  border-color: $border-color;
-  border-radius: $border-radius;
-  background-color: $background-color;
+  border: 1px solid;
+  border-color: var(--silver);
+  border-radius: 10px;
+  background-color: #fff;
+  position: relative;
 
   &.error {
     @apply block w-full border-red-300 text-red-900 placeholder-red-300;
@@ -76,26 +35,45 @@ $background-color: #fff;
   }
 
   & + .errorlist {
-    @apply -mx-5;
+    margin-top: -1.25rem;
   }
 
   &:focus-within {
-    box-shadow: 0 0 0 1px $focus-color;
-    border-color: $focus-color;
+    border-color: var(--primary-accent);
   }
 
-  > .input-box { // div with styling hook
-    @apply mx-4 flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
+  > .input-box {
+    // div with styling hook
+    @apply mx-4 flex items-center;
 
-    input:not(:focus)::placeholder,
-    textarea:not(:focus)::placeholder {
-      @apply text-transparent;
+    height: 100%;
+    position: relative;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
 
+    input:not(:focus)::placeholder {
       transition: color 200ms;
+      color: transparent;
     }
 
-    input:read-only {
-      @apply pointer-events-none;
+    @mixin label-focused {
+      color: var(--primary-accent) !important;
+      transform: translate(0, -250%) scale(0.75);
+      max-width: 130%;
+    }
+
+    @mixin label-resting {
+      transform-origin: top left;
+      text-align: left;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: 100%;
+    }
+
+    @mixin label-transition {
+      color: var(--slate);
+      transform: translate(0, -10%) scale(0.75);
     }
 
     input + label,
@@ -105,14 +83,10 @@ $background-color: #fff;
       @include label-resting;
     }
 
-    .ts-wrapper + label { // gives select room for the drop down arrow.
-      @apply pr-10;
-    }
-
     input:focus + label,
     .ts-wrapper.focus + label,
     textarea:focus + label {
-      @include label-focused($focus-label);
+      @include label-focused;
     }
 
     input:focus + label,
@@ -131,7 +105,7 @@ $background-color: #fff;
     select:-webkit-autofill:hover + label,
     select:-webkit-autofill:focus + label,
     .input:has(textarea:focus) + label {
-      @include label-focused;
+      @include label-transition;
     }
 
     // firefox does not support has queries, so turn off the label behavior there
@@ -163,14 +137,14 @@ $background-color: #fff;
     .input:has(input:-webkit-autofill) + label,
     .input:has(input:-webkit-autofill:hover) + label,
     .input:has(input:-webkit-autofill:focus) + label {
-      @include label-focused;
+      @include label-transition;
     }
     .input:has(textarea:focus) + label,
     .input:has(textarea:not(:placeholder-shown)) + label,
     .input:has(textarea:-webkit-autofill) + label,
     .input:has(textarea:-webkit-autofill:hover) + label,
     .input:has(textarea:-webkit-autofill:focus) + label {
-      @include label-focused;
+      @include label-transition;
     }
 
     @-moz-document url-prefix() {
@@ -185,21 +159,23 @@ $background-color: #fff;
       }
     }
 
-    // Front-end styling for tom-select
     .ts-wrapper {
-      @apply ring-0 w-full left-0 border bg-transparent pr-0;
+      @apply ring-0;
 
+      width: 100%;
       height: $input-height;
+      left: 0;
       border-radius: 5px;
-
-      &.multi {
-        padding-top: 20px !important;
-      }
+      border: 1px;
+      background: transparent;
+      padding-right: 0;
 
       .ts-control {
-        @apply border-0 w-full bg-transparent pl-0;
-
+        border: 0;
+        width: 100%;
+        background-color: transparent;
         padding-top: 20px;
+        padding-left: 0;
       }
 
       .ts-dropdown {
@@ -220,29 +196,23 @@ $background-color: #fff;
       }
     }
 
-    // textarea handles vertical alignment differently from inputs,
-    // so unique styling is needed.
-    textarea {
-      @apply pt-4;
-
-      line-height: calc($input-height / 2);
-      height: $textarea-height;
-    }
-
     input,
     textarea {
-      @apply px-0 ring-0 w-full border-0 bg-transparent;
+      @apply px-0 ring-0;
 
-      min-height: $input-height;
-      border-radius: $border-radius;
+      width: 100%;
+      height: 50px;
+      border-radius: 5px;
+      border: 1px;
+      background: transparent;
       transition: padding 0.3s;
 
       &:not(:placeholder-shown) {
-        @apply pt-5;
+        padding-top: 20px;
       }
 
       &:focus {
-        @apply pt-5;
+        padding-top: 20px;
       }
 
       @-moz-document url-prefix() {
@@ -259,6 +229,12 @@ $background-color: #fff;
       }
     }
 
+    textarea {
+      margin-top: 20px;
+      padding-top: 0 !important;
+      border: 0 !important;
+    }
+
     input:-webkit-autofill,
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,
@@ -270,6 +246,19 @@ $background-color: #fff;
     select:-webkit-autofill:focus {
       background-clip: text;
       font-size: inherit;
+    }
+
+    label {
+      @apply absolute pointer-events-none block;
+
+      display: block;
+      position: absolute;
+      pointer-events: none;
+      top: 0;
+      line-height: $input-height;
+      transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+      transform: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+      color: var(--slate);
     }
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -1,6 +1,28 @@
 /* stylelint-disable no-descending-specificity */
+/* stylelint-disable at-rule-no-unknown */
 
-$input-height: 50px;
+
+/*
+  This file controls the styling for "material" inputs.
+
+  Note: Animations will only display if the input includes a placeholder!
+  If your inputs appear to always be in the "focused" state, look there first.
+  Included is an optional js/components/material.ts file which will
+  replace empty placeholders with the adjacent input labels.
+
+  inputs are styled in the order of .field > .input-box > [input]
+  rem units are being used to keep things proportional, but we have a bit less
+  control over t-s (tom-select) which is being styled using px.
+*/
+
+// base guidelines for styles. All assume a base font size of 16
+$input-height: 3.75rem;                    // 60px
+$textarea-height: calc($input-height * 3); // replace with "auto" to default to HTML rows
+$border-radius: 0.5rem;                    // 8px
+$focus-color: var(--primary-focus);        // Outline of focused text elements
+$focus-label: var(--primary);              // color of focused label
+$border-color: var(--silver);
+$background-color: #fff;
 
 .form-wrapper {
   @apply space-y-5 flex flex-row flex-wrap;
@@ -16,18 +38,37 @@ $input-height: 50px;
   }
 
   select ~ label {
-    z-index: 2;
+    z-index: 1;
   }
 }
 
-.field {
-  @apply mt-1;
 
-  border: 1px solid;
-  border-color: var(--silver);
-  border-radius: 10px;
-  background-color: #fff;
-  position: relative;
+@mixin label-focused($text-color:false) {
+  @apply top-0 left-0 pt-2 pb-2 text-xs leading-3 w-full;
+
+  @if $text-color {
+    color: $text-color;
+  }
+  background-color: $background-color;
+}
+
+// label for empty, unfocused input.
+@mixin label-resting {
+  @apply text-left truncate max-w-full;
+  @apply absolute pointer-events-none block top-0 w-full overflow-hidden;
+
+  line-height: $input-height;
+  transition: all 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    background-color 0s ease-out 200ms;
+}
+
+.field { // wrapper element for input/label, provides basic styling for input
+  @apply border relative h-auto;
+
+  border-color: $border-color;
+  border-radius: $border-radius;
+  background-color: $background-color;
 
   &.error {
     @apply block w-full border-red-300 text-red-900 placeholder-red-300;
@@ -35,45 +76,26 @@ $input-height: 50px;
   }
 
   & + .errorlist {
-    margin-top: -1.25rem;
+    @apply -mx-5;
   }
 
   &:focus-within {
-    border-color: var(--primary-accent);
+    box-shadow: 0 0 0 1px $focus-color;
+    border-color: $focus-color;
   }
 
-  > .input-box {
-    // div with styling hook
-    @apply mx-4 flex items-center;
+  > .input-box { // div with styling hook
+    @apply mx-4 flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
 
-    height: 100%;
-    position: relative;
-    overflow-x: hidden;
-    text-overflow: ellipsis;
+    input:not(:focus)::placeholder,
+    textarea:not(:focus)::placeholder {
+      @apply text-transparent;
 
-    input:not(:focus)::placeholder {
       transition: color 200ms;
-      color: transparent;
     }
 
-    @mixin label-focused {
-      color: var(--primary-accent) !important;
-      transform: translate(0, -250%) scale(0.75);
-      max-width: 130%;
-    }
-
-    @mixin label-resting {
-      transform-origin: top left;
-      text-align: left;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      max-width: 100%;
-    }
-
-    @mixin label-transition {
-      color: var(--slate);
-      transform: translate(0, -10%) scale(0.75);
+    input:read-only {
+      @apply pointer-events-none;
     }
 
     input + label,
@@ -83,10 +105,14 @@ $input-height: 50px;
       @include label-resting;
     }
 
+    .ts-wrapper + label { // gives select room for the drop down arrow.
+      @apply pr-10;
+    }
+
     input:focus + label,
     .ts-wrapper.focus + label,
     textarea:focus + label {
-      @include label-focused;
+      @include label-focused($focus-label);
     }
 
     input:focus + label,
@@ -105,7 +131,7 @@ $input-height: 50px;
     select:-webkit-autofill:hover + label,
     select:-webkit-autofill:focus + label,
     .input:has(textarea:focus) + label {
-      @include label-transition;
+      @include label-focused;
     }
 
     // firefox does not support has queries, so turn off the label behavior there
@@ -137,14 +163,14 @@ $input-height: 50px;
     .input:has(input:-webkit-autofill) + label,
     .input:has(input:-webkit-autofill:hover) + label,
     .input:has(input:-webkit-autofill:focus) + label {
-      @include label-transition;
+      @include label-focused;
     }
     .input:has(textarea:focus) + label,
     .input:has(textarea:not(:placeholder-shown)) + label,
     .input:has(textarea:-webkit-autofill) + label,
     .input:has(textarea:-webkit-autofill:hover) + label,
     .input:has(textarea:-webkit-autofill:focus) + label {
-      @include label-transition;
+      @include label-focused;
     }
 
     @-moz-document url-prefix() {
@@ -159,23 +185,21 @@ $input-height: 50px;
       }
     }
 
+    // Front-end styling for tom-select
     .ts-wrapper {
-      @apply ring-0;
+      @apply ring-0 w-full left-0 border bg-transparent pr-0;
 
-      width: 100%;
       height: $input-height;
-      left: 0;
       border-radius: 5px;
-      border: 1px;
-      background: transparent;
-      padding-right: 0;
+
+      &.multi {
+        padding-top: 20px !important;
+      }
 
       .ts-control {
-        border: 0;
-        width: 100%;
-        background-color: transparent;
+        @apply border-0 w-full bg-transparent pl-0;
+
         padding-top: 20px;
-        padding-left: 0;
       }
 
       .ts-dropdown {
@@ -196,23 +220,29 @@ $input-height: 50px;
       }
     }
 
+    // textarea handles vertical alignment differently from inputs,
+    // so unique styling is needed.
+    textarea {
+      @apply pt-4;
+
+      line-height: calc($input-height / 2);
+      height: $textarea-height;
+    }
+
     input,
     textarea {
-      @apply px-0 ring-0;
+      @apply px-0 ring-0 w-full border-0 bg-transparent;
 
-      width: 100%;
-      height: 50px;
-      border-radius: 5px;
-      border: 1px;
-      background: transparent;
+      min-height: $input-height;
+      border-radius: $border-radius;
       transition: padding 0.3s;
 
       &:not(:placeholder-shown) {
-        padding-top: 20px;
+        @apply pt-5;
       }
 
       &:focus {
-        padding-top: 20px;
+        @apply pt-5;
       }
 
       @-moz-document url-prefix() {
@@ -229,12 +259,6 @@ $input-height: 50px;
       }
     }
 
-    textarea {
-      margin-top: 20px;
-      padding-top: 0 !important;
-      border: 0 !important;
-    }
-
     input:-webkit-autofill,
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,
@@ -246,19 +270,6 @@ $input-height: 50px;
     select:-webkit-autofill:focus {
       background-clip: text;
       font-size: inherit;
-    }
-
-    label {
-      @apply absolute pointer-events-none block;
-
-      display: block;
-      position: absolute;
-      pointer-events: none;
-      top: 0;
-      line-height: $input-height;
-      transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-      transform: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-      color: var(--slate);
     }
   }
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -75,7 +75,7 @@ $background-color: #fff;
   > .input-box { // div with styling hook
     @apply flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
 
-    &.input {
+    &.input, &.select {
       @apply mx-4;
     }
     &.textarea {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -1,9 +1,45 @@
 /* stylelint-disable no-descending-specificity */
+/* stylelint-disable at-rule-no-unknown */
 
-$input-height: 50px;
 
-.form-wrapper {
-  @apply space-y-5 flex flex-row flex-wrap;
+/*
+  This file controls the styling for "material" inputs.
+
+  inputs are styled in the order of .field > .input-box > [input]
+  rem units are being used to keep things proportional on the tailwind side,
+  but we have a bit less control over t-s (tom-select) which is being styled using px.
+*/
+
+// base guidelines for styles. All assume a base font size of 16
+$input-height: 3.75rem;                    // 60px
+$textarea-height: calc($input-height * 3); // replace with "auto" to default to HTML rows
+$border-radius: 0.5rem;                    // 8px
+$focus-color: var(--primary-focus);        // Outline of focused text elements
+$focus-label: var(--primary);              // color of focused label
+$border-color: var(--silver);
+$background-color: #fff;
+
+// label for focused input, Optionally can change the label color of focused element.
+@mixin label-focused($text-color:false) {
+  @apply top-0 left-0 pt-2 pb-2 text-xs leading-3;
+
+  @if $text-color {
+    color: $text-color;
+  }
+
+  width: calc(100% - 0.75rem);
+  background-color: $background-color;
+}
+
+// label for empty, unfocused input.
+@mixin label-resting {
+  @apply text-left truncate max-w-full;
+  @apply absolute pointer-events-none block top-0 w-full overflow-hidden;
+
+  line-height: $input-height;
+  transition: all 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    background-color 0s ease-out 200ms;
 }
 
 .select {
@@ -20,14 +56,12 @@ $input-height: 50px;
   }
 }
 
-.field {
-  @apply mt-1;
+.field { // wrapper element for input/label, provides basic styling for input
+  @apply border relative h-auto;
 
-  border: 1px solid;
-  border-color: var(--silver);
-  border-radius: 10px;
-  background-color: #fff;
-  position: relative;
+  border-color: $border-color;
+  border-radius: $border-radius;
+  background-color: $background-color;
 
   &.error {
     @apply block w-full border-red-300 text-red-900 placeholder-red-300;
@@ -35,154 +69,100 @@ $input-height: 50px;
   }
 
   & + .errorlist {
-    margin-top: -1.25rem;
+    @apply -mx-5;
   }
 
   &:focus-within {
-    border-color: var(--primary-accent);
+    box-shadow: 0 0 0 1px $focus-color;
+    border-color: $focus-color;
   }
 
-  > .input-box {
-    // div with styling hook
-    @apply mx-4 flex items-center;
+  > .input-box { // div with styling hook
+    @apply flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
 
-    height: 100%;
-    position: relative;
-    overflow-x: hidden;
-    text-overflow: ellipsis;
+    &.input {
+      @apply mx-4;
+    }
+    &.textarea {
+      @apply ml-4;
+    }
+    // textarea handles vertical alignment differently from inputs,
+    // so unique styling is needed.
+    textarea {
+      @apply pt-4;
 
-    input:not(:focus)::placeholder {
-      transition: color 200ms;
+      line-height: calc($input-height / 2);
+      height: $textarea-height;
+    }
+
+    input,
+    textarea {
+      @apply px-0 ring-0 w-full border-0 bg-transparent;
+
+      min-height: $input-height;
+      border-radius: $border-radius;
+      transition: padding 0.3s;
+
+      &:not(:placeholder-shown), &:focus {
+        @apply pt-5;
+      }
+      &:read-only {
+        @apply pointer-events-none;
+
+      }
+    }
+
+    .ts-wrapper + label,
+    .input ~ label,
+    .password ~ label,
+    select + label { // default position for input labels
+      @include label-resting;
+    }
+
+    .has-focus ~ label,
+    .ts-wrapper.focus + label {
+      @include label-focused($focus-label);
+    }
+
+    .ts-wrapper.focus + label,
+    .ts-wrapper.has-items + label,
+    select:-webkit-autofill:hover + label,
+    select:-webkit-autofill:focus + label {
+      @include label-focused;
+    }
+
+    .input:not(.has-focus) input::placeholder,
+    .input:not(.has-focus) textarea::placeholder,
+    .password:not(.has-focus) input::placeholder {
       color: transparent;
     }
 
-    @mixin label-focused {
-      color: var(--primary-accent) !important;
-      transform: translate(0, -250%) scale(0.75);
-      max-width: 130%;
-    }
-
-    @mixin label-resting {
-      transform-origin: top left;
-      text-align: left;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      max-width: 100%;
-    }
-
-    @mixin label-transition {
-      color: var(--slate);
-      transform: translate(0, -10%) scale(0.75);
-    }
-
-    input + label,
-    .ts-wrapper + label,
-    select + label,
-    textarea + label {
-      @include label-resting;
-    }
-
-    input:focus + label,
-    .ts-wrapper.focus + label,
-    textarea:focus + label {
-      @include label-focused;
-    }
-
-    input:focus + label,
-    input:not(:placeholder-shown) + label,
-    .ts-wrapper.focus + label,
-    .ts-wrapper.has-items + label,
-    textarea:focus + label,
-    textarea:not(:placeholder-shown) + label,
-    input:-webkit-autofill + label,
-    input:-webkit-autofill:hover + label,
-    input:-webkit-autofill:focus + label,
-    textarea:-webkit-autofill + label,
-    textarea:-webkit-autofill:hover + label,
-    textarea:-webkit-autofill:focus + label,
-    select:-webkit-autofill + label,
-    select:-webkit-autofill:hover + label,
-    select:-webkit-autofill:focus + label,
-    .input:has(textarea:focus) + label {
-      @include label-transition;
-    }
-
-    // firefox does not support has queries, so turn off the label behavior there
-    .password:has(input) + label,
-    .input:has(input) + label {
-      @include label-resting;
-    }
-
-    .password:has(input:focus) + label,
-    .input:has(input:focus) + label {
-      @include label-focused;
-    }
-
-    .input:has(textarea) + label {
-      @include label-resting;
-    }
-
-    .input:has(textarea:focus) + label {
-      @include label-focused;
-    }
-
-    .password:has(input:focus) + label,
-    .password:has(input:not(:placeholder-shown)) + label,
-    .password:has(input:-webkit-autofill) + label,
-    .password:has(input:-webkit-autofill:hover) + label,
-    .password:has(input:-webkit-autofill:focus) + label,
-    .input:has(input:focus) + label,
-    .input:has(input:not(:placeholder-shown)) + label,
-    .input:has(input:-webkit-autofill) + label,
-    .input:has(input:-webkit-autofill:hover) + label,
-    .input:has(input:-webkit-autofill:focus) + label {
-      @include label-transition;
-    }
-    .input:has(textarea:focus) + label,
-    .input:has(textarea:not(:placeholder-shown)) + label,
-    .input:has(textarea:-webkit-autofill) + label,
-    .input:has(textarea:-webkit-autofill:hover) + label,
-    .input:has(textarea:-webkit-autofill:focus) + label {
-      @include label-transition;
-    }
-
-    @-moz-document url-prefix() {
-      .password + label,
-      .input + label {
-        display: none;
-      }
-
-      .password input::placeholder,
-      .input input::placeholder {
-        color: var(--slate);
-      }
-    }
-
+    // Font-end styling for tom-select
     .ts-wrapper {
-      @apply ring-0;
+      @apply ring-0 w-full left-0 border bg-transparent pr-0;
 
-      width: 100%;
       height: $input-height;
-      left: 0;
       border-radius: 5px;
-      border: 1px;
-      background: transparent;
-      padding-right: 0;
+
+      + label { // gives select room for the drop down arrow
+        @apply pr-10;
+      }
+
+      &.multi {
+        padding-top: 20px !important;
+      }
 
       .ts-control {
-        border: 0;
-        width: 100%;
-        background-color: transparent;
+        @apply border-0 w-full bg-transparent pl-0;
+
         padding-top: 20px;
-        padding-left: 0;
       }
 
       .ts-dropdown {
-        margin: 4px 0 0;
+        margin: 12px 0 0;
         border-radius: 8px;
-        left: -22px;
-        width: calc(100% + 44px);
+        left: -16px;
+        width: calc(100% + 16px);
 
         .ts-dropdown-content {
           padding: 0;
@@ -196,45 +176,7 @@ $input-height: 50px;
       }
     }
 
-    input,
-    textarea {
-      @apply px-0 ring-0;
-
-      width: 100%;
-      height: 50px;
-      border-radius: 5px;
-      border: 1px;
-      background: transparent;
-      transition: padding 0.3s;
-
-      &:not(:placeholder-shown) {
-        padding-top: 20px;
-      }
-
-      &:focus {
-        padding-top: 20px;
-      }
-
-      @-moz-document url-prefix() {
-        &:not(:placeholder-shown) {
-          padding-top: 8px;
-        }
-
-        &:focus {
-          padding-top: 8px;
-        }
-      }
-      &[type=file] {
-        height: 56px;
-      }
-    }
-
-    textarea {
-      margin-top: 20px;
-      padding-top: 0 !important;
-      border: 0 !important;
-    }
-
+    // removes input styling that some browsers apply to autofilled elements
     input:-webkit-autofill,
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,
@@ -247,38 +189,10 @@ $input-height: 50px;
       background-clip: text;
       font-size: inherit;
     }
-
-    label {
-      @apply absolute pointer-events-none block;
-
-      display: block;
-      position: absolute;
-      pointer-events: none;
-      top: 0;
-      line-height: $input-height;
-      transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-      transform: 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-      color: var(--slate);
-    }
   }
 }
 
-.boolean-field {
-  &.error {
-    button {
-      @apply border-2 border-red-300;
-    }
-  }
-}
-
-.radio-field {
-  &.error {
-    .radio-choice-ring {
-      @apply ring-red-300;
-    }
-  }
-}
-
+// global/admin styling for tom-select
 .ts-wrapper {
   @apply px-4 ring-0;
 
@@ -286,14 +200,6 @@ $input-height: 50px;
     .ts-control {
       box-shadow: none;
       border-color: var(--primary-accent);
-    }
-  }
-
-  &.has-items {
-    .ts-control {
-      input {
-        // opacity: 0; // uncomment this to hide input after select
-      }
     }
   }
 
@@ -305,18 +211,24 @@ $input-height: 50px;
   }
 
   .ts-dropdown {
-    margin: 4px 0 0;
-    border-radius: 8px;
+    padding: 2px; // Prevents scrollbar from overlapping border
+    border: 1px solid var(--dark-gray);
+    color: var(--primary);
 
     .active {
-      background-color: var(--silver);
+      @apply bg-opacity-10;
+
       font-weight: 600;
-      color: var(--primary-accent);
+      color: var(--primary-focus);
     }
 
     .option {
       padding-left: 16px;
       margin: 4px;
+      height: $input-height;
+      display: flex;
+      align-items: center;
+      white-space: nowrap;
     }
 
     .ts-dropdown-content {
@@ -326,19 +238,26 @@ $input-height: 50px;
         line-height: 48px;
         border-radius: 6px;
         margin: 4px;
+
+        &.selected {
+          text-decoration: none;
+        }
       }
     }
   }
 }
 
+
 .left-icon {
-  @apply absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none;
+  @apply inset-y-0 relative left-0 flex items-center pointer-events-none z-10;
+  background-color: $background-color;
 }
 
 .right-icon {
-  @apply absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none;
+  @apply inset-y-0 absolute right-0 flex items-center pointer-events-none z-10;
+  background-color: $background-color;
 }
 
-.password ~ .right-icon {
-  @apply pr-7;
+.form-wrapper {
+  @apply flex flex-row flex-wrap gap-7;
 }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/checkbox.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/checkbox.jinja
@@ -1,6 +1,6 @@
 {% macro checkbox(field) %}
     <div class="relative flex items-start">
-        <div class="flex items-center h-5 field">{{ field }}</div>
+        <div class="flex items-center h-5">{{ field }}</div>
         <div class="ml-3 text-sm">
             {% if field.label %}{{ field.label_tag() }}{% endif %}
             <p class="text-gray-500" id="email-description">

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
@@ -5,6 +5,8 @@
         select
     {%- elif field.widget_type == "radioselect" -%}
         radio
+    {%- elif field.widget_type == "textarea" -%}
+        textarea
     {%- else -%}
         input
     {%- endif -%}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
@@ -6,7 +6,7 @@
         x-ref="input"
         :class="active ? 'has-focus' : ''"
          class="w-full input">
-        <input @transitionstart="updateFlag" x-model.debounce.500ms="value" class="{{ input_classes }}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
+        <input @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" class="{{ input_classes }}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
     </div>
 {% endmacro %}
 {# takes a django widget and calls our input macro with the appropriate args #}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
@@ -3,8 +3,10 @@
     {% set disabled, readonly = attrs.disabled, attrs.readonly %}
     {% set noedit = disabled or readonly %}
     <div x-data="input('update-{{ event_name | replace('_', '-') }}', '{{ value }}')"
+        x-ref="input"
+        :class="active ? 'has-focus' : ''"
          class="w-full input">
-        <input x-model.debounce.500ms="value" class="{{input_classes}}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
+        <input @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" class="{{input_classes}}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
     </div>
 {% endmacro %}
 {# takes a django widget and calls our input macro with the appropriate args #}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
@@ -6,7 +6,7 @@
         x-ref="input"
         :class="active ? 'has-focus' : ''"
          class="w-full input">
-        <input @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" class="{{input_classes}}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
+        <input @transitionstart="updateFlag" x-model.debounce.500ms="value" class="{{ input_classes }}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
     </div>
 {% endmacro %}
 {# takes a django widget and calls our input macro with the appropriate args #}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
@@ -4,9 +4,22 @@ import { AlpineDataCallback } from "../../static_source/js";
 const input = (eventName: string, value: string): AlpineComponent => ({
   eventName,
   value,
+  active: false,
+  updateFlag() {
+    const childInput:HTMLInputElement|null = this.$refs.input.querySelector("input, textarea");
+    if (!childInput) {
+      return;
+    }
+    if (!childInput.value) {
+      this.active = !this.active;
+    }
+  },
   init() {
     if (this.value === "None") {
       this.value = "";
+    } else if (this.$refs !== undefined && "input" in this.$refs) {
+      // Toggle the focused state on an input label when an initial value is set.
+      this.active = !this.active;
     }
     if (this.eventName !== "input") {
       this.$watch("value", () => {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
@@ -3,7 +3,7 @@
     <div x-data="password('update-{{ event_name | replace('_', '-') }}', '{{ value }}', 'password')" x-ref="input"
         :class="active ? 'has-focus' : ''"
          class="w-full z-10 flex items-center relative password">
-        <input @transitionstart="updateFlag" x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
+        <input  @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
         <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
              @click="type='password'"
              x-cloak

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
@@ -1,8 +1,9 @@
 {% from 'components/util.jinja' import attributes %}
 {% macro password(name='password', value=None, event_name="", attrs={}) %}
-    <div x-data="password('update-{{ event_name | replace('_', '-') }}', '{{ value }}', 'password')"
-         class="w-full flex items-center relative password">
-        <input x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
+    <div x-data="password('update-{{ event_name | replace('_', '-') }}', '{{ value }}', 'password')" x-ref="input"
+        :class="active ? 'has-focus' : ''"
+         class="w-full z-10 flex items-center relative password">
+        <input @transitionstart="updateFlag" x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
         <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
              @click="type='password'"
              x-cloak

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.ts
@@ -5,6 +5,16 @@ const password = (eventName: unknown, value: unknown, type: unknown): AlpineComp
   eventName,
   value,
   type,
+  active: false,
+  updateFlag() {
+    const childInput:HTMLInputElement|null = this.$refs.input.querySelector("input, textarea");
+    if (!childInput) {
+      return;
+    }
+    if (!childInput.value) {
+      this.active = !this.active;
+    }
+  },
   init() {
     if (this.value === "None") {
       this.value = "";

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
@@ -1,9 +1,11 @@
 {% from 'components/util.jinja' import attributes %}
 {% macro text_area(type="text", name=none, value=none, event_name="", color='primary', attrs={}, left_icon='', right_icon='') %}
     <div x-data="input('update-{{ event_name | replace('_', '-') }}', '{{ value }}')"
+        :class="active ? 'has-focus' : ''"
+        x-ref="input"
          class="w-full input">
         <textarea
-            x-model.debounce.500ms="value"
+            x-model.debounce.500ms="value" @focus="updateFlag" @blur="updateFlag"
             {% do attrs.update({"type": type, "name": name, "value": value}) %}
             {{ attributes(attrs)}}
         >

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
@@ -5,7 +5,7 @@
         x-ref="input"
          class="w-full input">
         <textarea
-            x-model.debounce.500ms="value" @focus="updateFlag" @blur="updateFlag"
+            x-model.debounce.500ms="value" @transitionstart="updateFlag"
             {% do attrs.update({"type": type, "name": name, "value": value}) %}
             {{ attributes(attrs)}}
         >

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/textarea.jinja
@@ -5,7 +5,8 @@
         x-ref="input"
          class="w-full input">
         <textarea
-            x-model.debounce.500ms="value" @transitionstart="updateFlag"
+            @focus="updateFlag" @blur="updateFlag"
+            x-model.debounce.500ms="value"
             {% do attrs.update({"type": type, "name": name, "value": value}) %}
             {{ attributes(attrs)}}
         >


### PR DESCRIPTION
# Short description

This pull request refactors the existing input CSS by using alpine state management to apply focus classes. This is primarily to address a growing dependence on the :has selector within recent PRs (specifically regarding validation), which broke most input functionality in firefox. Rather than relying on pseudoselectors, this PR implements alpine event listeners.

# Any point in the PR you think needs extra attention

There is (arguably) a bug with autofill fields where input text will overlap the label briefly if > 2 fields are filled at the same time. Once an autoselect option is selected, the label will adjust appropriately. (See video below for an example.) This can be resolved by using an [@transitionstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/transitionstart_event) (or similar) event listener with Alpine, but current styling caused the event to fire multiple times. There is also the possibility that this event would ultimately be too sensitive for this usage, as it toggles whenever _any_ event is run on the attached input.

https://user-images.githubusercontent.com/80595928/228084578-fd6f0aac-f657-43cd-a74d-2a5e9f2d80ca.mov

# New Features or Fixes 
1. Toggle active class to input fields to remove reliance on pseudoselectors
2. Template in CSS to allow easier editing of colors and sizing
3. Switched sizing from px to rem to play nicer with tailwind  (with the exception of tom-select elements)
4. Improved previously jumpy animations
5. Added functional textareas
6. Removed unused class from checkboxes which caused odd rendering
7. Removed instances where multiple icons were displayed in inputs (primarily error states). In the case that an error indicator and functional icon (such as tooltip) were displayed, the error icon will retain the original's behavior.

# Video of feature working

Example demonstrating class toggling (in source panel); error state icon with proper functionality

https://user-images.githubusercontent.com/80595928/228086047-6c9fb58c-81a5-4384-a33a-1b413b35845a.mov

Example of a working textarea (note floating label)

https://user-images.githubusercontent.com/80595928/228086208-c8e9b04a-1770-4e01-82ae-f1058f07f02c.mov