### PR TITLE
Hotfix/linting inputs

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -1,6 +1,4 @@
 /* stylelint-disable no-descending-specificity */
-/* stylelint-disable at-rule-no-unknown */
-
 
 /*
   This file controls the styling for "material" inputs.

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -119,8 +119,7 @@ $background-color: #fff;
     .ts-wrapper.has-items + label,
     select:-webkit-autofill:hover + label,
     select:-webkit-autofill:focus + label,
-    .has-focus ~ label,
-    .ts-wrapper.focus + label {
+    .has-focus ~ label {
       @include label-focused;
     }
 


### PR DESCRIPTION
This PR updates the forms.scss file to address a couple linting hiccups - namely a duplicate selector and disabling a (now unused) linter ignore rule.