### PR TITLE
Setup ruff to fix import sorting

### DIFF
--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -47,9 +47,13 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.0.215'
+    rev: 'v0.0.259'
     hooks:
       - id: ruff
+        args: [
+                --fix,
+                --exit-non-zero-on-fix,
+              ]
 
   # TODO:  https://github.com/adamchainz/pre-commit-oxipng
 


### PR DESCRIPTION
previously ruff would not auto-sort imports, but would detect exit non-zero if they were not sorted.

This lets ruff sort them, making it a true replacement for isort