### PR TITLE
Feature/input improvements

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -1,9 +1,11 @@
 /* stylelint-disable no-descending-specificity */
+/* stylelint-disable block-no-empty */
+
 
 /*
   This file controls the styling for "material" inputs.
 
-  inputs are styled in the order of .field > .input-box > [input]
+  inputs are styled in the order of .field > [input]
   rem units are being used to keep things proportional on the tailwind side,
   but we have a bit less control over t-s (tom-select) which is being styled using px.
 */
@@ -36,6 +38,19 @@ $background-color: #fff;
     background-color 0s ease-out 200ms;
 }
 
+// Neither of these animations have a visible effect - they are used as flags for autofill
+@keyframes autofill-start {
+  from {}
+
+  to {}
+}
+
+@keyframes autofill-cancel {
+  from {}
+
+  to {}
+}
+
 .select {
   overflow-x: visible !important;
   min-height: $input-height; // prevent flash of content from tom select starting up
@@ -52,6 +67,7 @@ $background-color: #fff;
 
 .field { // wrapper element for input/label, provides basic styling for input
   @apply border relative h-auto;
+  @apply flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
 
   border-color: $border-color;
   border-radius: $border-radius;
@@ -71,115 +87,140 @@ $background-color: #fff;
     border-color: $focus-color;
   }
 
-  > .input-box { // div with styling hook
-    @apply flex items-center h-full relative overflow-x-hidden overflow-ellipsis;
+  & .input,
+  & .input ~ label,
+  & .select,
+  & .select ~ label {
+    @apply px-4;
+  }
 
-    &.input, &.select {
-      @apply mx-4;
+  & .textarea {
+    @apply ml-4;
+  }
+
+  .password {
+    & input,
+    & ~ label {
+      @apply px-4;
     }
-    &.textarea {
-      @apply ml-4;
+    & input:focus {
+      @apply ring-0;
     }
+  }
 
-    input,
-    textarea {
-      @apply px-0 ring-0 w-full border-0 bg-transparent;
+  input,
+  textarea {
+    @apply px-0 ring-0 w-full border-0 bg-transparent;
 
-      min-height: $input-height;
-      border-radius: $border-radius;
-      transition: padding 0.3s;
+    min-height: $input-height;
+    border-radius: $border-radius;
+    transition: padding 0.3s;
 
-      &:not(:placeholder-shown), &:focus {
-        @apply pt-5;
-      }
-      &:read-only {
-        @apply pointer-events-none;
-
-      }
-    }
-
-    // textarea handles vertical alignment differently from inputs,
-    // so unique styling is needed.
-    textarea {
-      @apply pt-4 pr-3;
-
-      line-height: calc($input-height / 2);
-      height: $textarea-height;
+    &:not(:placeholder-shown),
+    &:focus {
+      @apply pt-5;
     }
 
-    .ts-wrapper + label,
-    .input ~ label,
-    .password ~ label,
-    select + label { // default position for input labels
-      @include label-resting;
+    &:read-only {
+      @apply pointer-events-none;
     }
 
-    .ts-wrapper.focus + label,
-    .ts-wrapper.has-items + label,
-    select:-webkit-autofill:hover + label,
-    select:-webkit-autofill:focus + label,
-    .has-focus ~ label {
-      @include label-focused;
+    // these are placeholder animations which allow us to attach an event listener
+    // to inputs that have been autofilled. Without a duration, styles are applied with
+    // "automatic" autofill but not with drop down. Props to the Klarna UI team for
+    // this solution.
+    &:-webkit-autofill {
+      animation-name: autofill-start;
+      animation-duration: 0.001s;
     }
 
-    .input:not(.has-focus) input::placeholder,
-    .input:not(.has-focus) textarea::placeholder,
-    .password:not(.has-focus) input::placeholder {
-      color: transparent;
+    &:not(:-webkit-autofill) {
+      animation-name: autofill-cancel;
+      animation-duration: 0.001s;
+    }
+  }
+
+  // textarea handles vertical alignment differently from inputs,
+  // so unique styling is needed.
+  textarea {
+    @apply pt-4 pr-3;
+
+    line-height: calc($input-height / 2);
+    height: $textarea-height;
+  }
+
+  .ts-wrapper + label,
+  .input ~ label,
+  .password ~ label,
+  select + label { // default position for input labels
+    @include label-resting;
+  }
+
+  .ts-wrapper.has-items + label,
+  select:-webkit-autofill:hover + label,
+  select:-webkit-autofill:focus + label,
+  .has-focus ~ label,
+  .ts-wrapper.focus + label {
+    @include label-focused;
+  }
+
+  .input:not(.has-focus).input::placeholder,
+  .input:not(.has-focus).textarea::placeholder,
+  .password:not(.has-focus) input::placeholder {
+    color: transparent;
+  }
+
+  // Font-end styling for tom-select
+  .ts-wrapper {
+    @apply ring-0 w-full left-0 border bg-transparent pr-0;
+
+    height: $input-height;
+    border-radius: 5px;
+
+    + label { // gives select room for the drop down arrow
+      @apply pr-10;
     }
 
-    // Font-end styling for tom-select
-    .ts-wrapper {
-      @apply ring-0 w-full left-0 border bg-transparent pr-0;
+    &.multi {
+      padding-top: 20px !important;
+    }
 
-      height: $input-height;
-      border-radius: 5px;
+    .ts-control {
+      @apply border-0 w-full bg-transparent pl-0;
 
-      + label { // gives select room for the drop down arrow
-        @apply pr-10;
-      }
+      padding-top: 20px;
+    }
 
-      &.multi {
-        padding-top: 20px !important;
-      }
+    .ts-dropdown {
+      margin: 12px 0 0;
+      border-radius: 8px;
+      left: -16px;
+      width: calc(100% + 16px);
 
-      .ts-control {
-        @apply border-0 w-full bg-transparent pl-0;
+      .ts-dropdown-content {
+        padding: 0;
 
-        padding-top: 20px;
-      }
-
-      .ts-dropdown {
-        margin: 12px 0 0;
-        border-radius: 8px;
-        left: -16px;
-        width: calc(100% + 16px);
-
-        .ts-dropdown-content {
-          padding: 0;
-
-          .option {
-            line-height: 48px;
-            border-radius: 6px;
-            margin: 4px;
-          }
+        .option {
+          line-height: 48px;
+          border-radius: 6px;
+          margin: 4px;
         }
       }
     }
+  }
 
-    // removes input styling that some browsers apply to autofilled elements
-    input:-webkit-autofill,
-    input:-webkit-autofill:hover,
-    input:-webkit-autofill:focus,
-    textarea:-webkit-autofill,
-    textarea:-webkit-autofill:hover,
-    textarea:-webkit-autofill:focus,
-    select:-webkit-autofill,
-    select:-webkit-autofill:hover,
-    select:-webkit-autofill:focus {
-      background-clip: text;
-      font-size: inherit;
-    }
+  // removes input styling that some browsers apply to autofilled elements
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  textarea:-webkit-autofill,
+  textarea:-webkit-autofill:hover,
+  textarea:-webkit-autofill:focus,
+  select:-webkit-autofill,
+  select:-webkit-autofill:hover,
+  select:-webkit-autofill:focus {
+    background-clip: text;
+    font-size: inherit;
   }
 }
 
@@ -247,6 +288,7 @@ $background-color: #fff;
 
 .right-icon {
   @apply inset-y-0 absolute right-0 flex items-center pointer-events-none z-10;
+
   background-color: $background-color;
 }
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -129,7 +129,7 @@ $background-color: #fff;
     // to inputs that have been autofilled. Without a duration, styles are applied with
     // "automatic" autofill but not with drop down. Props to the Klarna UI team for
     // this solution.
-    // https://stackoverflow.com/a/41530164/21726578
+    // https://medium.com/@brunn/detecting-autofilled-fields-in-javascript-aed598d25da7
     &:-webkit-autofill {
       animation-name: autofill-start;
       animation-duration: 0.001s;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/css/base/_forms.scss
@@ -129,6 +129,7 @@ $background-color: #fff;
     // to inputs that have been autofilled. Without a duration, styles are applied with
     // "automatic" autofill but not with drop down. Props to the Klarna UI team for
     // this solution.
+    // https://stackoverflow.com/a/41530164/21726578
     &:-webkit-autofill {
       animation-name: autofill-start;
       animation-duration: 0.001s;

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/field.jinja
@@ -12,15 +12,13 @@
     {%- endif -%}
 {%- endmacro -%}
 {% macro input_shell(field, errors='') %}
-    <div class="field {% if errors %}error{% endif %}">
-        <div class="input-box {{ input_widget_hook(field) }}">
+    <div class="field {% if errors %}error {% endif %}{{ input_widget_hook(field) }}">
             {{ field }}
             {% if field.label %}{{ field.label_tag() }}{% endif %}
             <div class="right-icon {% if errors is not none %}hidden{% endif %}">
                 {{ heroicon_solid("exclamation-circle", class="text-error")}}
             </div>
         </div>
-    </div>
 {% endmacro %}
 {% macro boolean_shell(field, errors='') %}
     <div class="boolean-field flex items-center {% if errors %} error{% endif %}">

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.jinja
@@ -2,12 +2,18 @@
 {% macro input(type="text", name=none, value=none, event_name="", color='primary', attrs={}, left_icon='', right_icon='', input_classes="") %}
     {% set disabled, readonly = attrs.disabled, attrs.readonly %}
     {% set noedit = disabled or readonly %}
-    <div x-data="input('update-{{ event_name | replace('_', '-') }}', '{{ value }}')"
-        x-ref="input"
-        :class="active ? 'has-focus' : ''"
-         class="w-full input">
-        <input @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" class="{{ input_classes }}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
-    </div>
+        <input
+        {% if type !="checkbox" %}
+            {#
+                The following attrs are responsible for frontend validation (not used in admin) and label behavior for inputs/texareas.
+                May also need to be disabled for radio buttons if admin misbehaves again.
+             #}
+            x-model.debounce.500ms="value"
+            :class="{'has-focus': active}"
+            @focus="updateFlag" @blur="updateFlag" @input="updateFlag"
+        {% endif %}
+        x-data="input('update-{{ event_name | replace('_', '-') }}', '{{ value }}')"
+        x-ref="input" class="input {{ input_classes }}" {% do attrs.update({"type": type, "name": name, "value": value}) %} {{ attributes(attrs)}} />
 {% endmacro %}
 {# takes a django widget and calls our input macro with the appropriate args #}
 {% macro widget_to_input(widget) %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/input.ts
@@ -5,20 +5,63 @@ const input = (eventName: string, value: string): AlpineComponent => ({
   eventName,
   value,
   active: false,
-  updateFlag() {
-    const childInput:HTMLInputElement|null = this.$refs.input.querySelector("input, textarea");
-    if (!childInput) {
+  updateFlag(e:Event) {
+    const currentInput:HTMLInputElement|null = this.$refs.input as HTMLInputElement;
+
+    // escape hatch for if the function's been attached to something that isn't an input
+    // (this should never happen!)
+    if (!currentInput) {
       return;
     }
-    if (!childInput.value) {
-      this.active = !this.active;
+
+    // if the input is focused, or has a value, set the active flag to true
+    // otherwise, set it to false
+    switch (e.type) {
+      case "focus":
+      case "input":
+        this.active = true;
+        break;
+      case "blur":
+        if (!currentInput.value) {
+          this.active = false;
+        } else {
+          this.active = true;
+        }
+        break;
+      default:
+    }
+
+    if (currentInput.classList.contains("autofilled")) {
+      currentInput.classList.remove("autofilled");
     }
   },
   init() {
+    // We're using the animationstart event to detect when the browser has autofilled
+    const currentInput = this.$refs.input as HTMLInputElement;
+    currentInput.addEventListener("animationstart", (e) => {
+      switch (e.animationName) {
+        case "autofill-start":
+          this.active = true;
+          currentInput.classList.add("autofilled");
+          break;
+        case "autofill-cancel":
+          if (document.activeElement === currentInput) {
+            this.active = true;
+          } else if (this.value === "") {
+            this.active = false;
+          }
+          if (!currentInput.value) {
+            currentInput.classList.remove("autofilled");
+          }
+          break;
+        default:
+      }
+    });
+
     if (this.value === "None") {
       this.value = "";
     } else if (this.$refs !== undefined && "input" in this.$refs) {
-      // Toggle the focused state on an input label when an initial value is set.
+      // Toggle the focused state on an input when an initial value is set.
       this.active = !this.active;
     }
     if (this.eventName !== "input") {

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/forms/password.jinja
@@ -4,13 +4,13 @@
         :class="active ? 'has-focus' : ''"
          class="w-full z-10 flex items-center relative password">
         <input  @focus="updateFlag" @blur="updateFlag" x-model.debounce.500ms="value" :type="type" name="{{ name }}" class="mr-8" {% if value != None %}value="{{ value }}"{% endif %} {{ attributes(attrs)}} />
-        <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
+        <div class="absolute inset-y-0 right-4 flex items-center cursor-pointer"
              @click="type='password'"
              x-cloak
              x-show="type==='text'">
             {{ heroicon_outline("eye-slash", class="w-6 h-6") }}
         </div>
-        <div class="absolute inset-y-0 right-0 flex items-center cursor-pointer"
+        <div class="absolute inset-y-0 right-4 flex items-center cursor-pointer"
              @click="type='text'"
              x-show="type==='password'">
             {{ heroicon_outline("eye", class="w-6 h-6") }}


### PR DESCRIPTION
This PR adds some tested features from previous projects to help solidify the use cases for class swapping on inputs.
Also removes a redundant wrapper div and further reduces CSS footprint!

Improvements to class toggles:
* detects autofill inputs
* removes fragility by explicitly define states based on expected values
* removed unused classes from checkboxes (radio TODO)
* removes div input wrapper which interfered with areas of django admin